### PR TITLE
Remove Vx Map from homepage and update API types

### DIFF
--- a/src/api/schema/Actuals.d.ts
+++ b/src/api/schema/Actuals.d.ts
@@ -56,7 +56,7 @@ export type Weeklycovidadmissions = number | null;
  *
  * Information about acute bed utilization details aggregated for the county's corresponding
  * Health Service Area (HSA). For CBSA, state, and country regions these fields are omitted.
- * For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
+ * For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
  *
  * Fields:
  *  * capacity - Current staffed acute bed capacity.
@@ -93,7 +93,7 @@ export type Currentusagecovid1 = number | null;
  *
  * Information about ICU bed utilization details aggregated for the county's corresponding
  * Health Service Area (HSA). For CBSA, state, and country regions these fields are omitted.
- * For For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
+ * For For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
  *
  * Fields:
  *  * capacity - Current staffed ICU bed capacity.
@@ -166,6 +166,10 @@ export type Vaccinationscompleted = number | null;
  */
 export type Vaccinationsadditionaldose = number | null;
 /**
+ * Number of individuals who have received a bivalent vaccine dose.
+ */
+export type Vaccinationsfall2022Bivalentbooster = number | null;
+/**
  * Total number of vaccine doses administered.
  */
 export type Vaccinesadministered = number | null;
@@ -209,6 +213,7 @@ export interface Actuals {
   vaccinationsInitiated?: Vaccinationsinitiated;
   vaccinationsCompleted?: Vaccinationscompleted;
   vaccinationsAdditionalDose?: Vaccinationsadditionaldose;
+  vaccinationsFall2022BivalentBooster?: Vaccinationsfall2022Bivalentbooster;
   vaccinesAdministered?: Vaccinesadministered;
   vaccinesAdministeredDemographics?: Vaccinesadministereddemographics;
   vaccinationsInitiatedDemographics?: Vaccinationsinitiateddemographics;

--- a/src/api/schema/ActualsTimeseriesRow.d.ts
+++ b/src/api/schema/ActualsTimeseriesRow.d.ts
@@ -56,7 +56,7 @@ export type Weeklycovidadmissions = number | null;
  *
  * Information about acute bed utilization details aggregated for the county's corresponding
  * Health Service Area (HSA). For CBSA, state, and country regions these fields are omitted.
- * For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
+ * For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
  *
  * Fields:
  *  * capacity - Current staffed acute bed capacity.
@@ -93,7 +93,7 @@ export type Currentusagecovid1 = number | null;
  *
  * Information about ICU bed utilization details aggregated for the county's corresponding
  * Health Service Area (HSA). For CBSA, state, and country regions these fields are omitted.
- * For For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
+ * For For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
  *
  * Fields:
  *  * capacity - Current staffed ICU bed capacity.
@@ -166,6 +166,10 @@ export type Vaccinationscompleted = number | null;
  */
 export type Vaccinationsadditionaldose = number | null;
 /**
+ * Number of individuals who have received a bivalent vaccine dose.
+ */
+export type Vaccinationsfall2022Bivalentbooster = number | null;
+/**
  * Total number of vaccine doses administered.
  */
 export type Vaccinesadministered = number | null;
@@ -213,6 +217,7 @@ export interface ActualsTimeseriesRow {
   vaccinationsInitiated?: Vaccinationsinitiated;
   vaccinationsCompleted?: Vaccinationscompleted;
   vaccinationsAdditionalDose?: Vaccinationsadditionaldose;
+  vaccinationsFall2022BivalentBooster?: Vaccinationsfall2022Bivalentbooster;
   vaccinesAdministered?: Vaccinesadministered;
   vaccinesAdministeredDemographics?: Vaccinesadministereddemographics;
   vaccinationsInitiatedDemographics?: Vaccinationsinitiateddemographics;

--- a/src/api/schema/AggregateFlattenedTimeseries.d.ts
+++ b/src/api/schema/AggregateFlattenedTimeseries.d.ts
@@ -92,7 +92,7 @@ export type Weeklycovidadmissions = number | null;
  *
  * Information about acute bed utilization details aggregated for the county's corresponding
  * Health Service Area (HSA). For CBSA, state, and country regions these fields are omitted.
- * For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
+ * For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
  *
  * Fields:
  *  * capacity - Current staffed acute bed capacity.
@@ -129,7 +129,7 @@ export type Currentusagecovid1 = number | null;
  *
  * Information about ICU bed utilization details aggregated for the county's corresponding
  * Health Service Area (HSA). For CBSA, state, and country regions these fields are omitted.
- * For For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
+ * For For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
  *
  * Fields:
  *  * capacity - Current staffed ICU bed capacity.
@@ -202,6 +202,10 @@ export type Vaccinationscompleted = number | null;
  */
 export type Vaccinationsadditionaldose = number | null;
 /**
+ * Number of individuals who have received a bivalent vaccine dose.
+ */
+export type Vaccinationsfall2022Bivalentbooster = number | null;
+/**
  * Total number of vaccine doses administered.
  */
 export type Vaccinesadministered = number | null;
@@ -268,11 +272,11 @@ export type Infectionrateci90 = number | null;
  */
 export type Icucapacityratio = number | null;
 /**
- * Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area.
+ * Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas
  */
 export type Bedswithcovidpatientsratio = number | null;
 /**
- * Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area.
+ * Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas
  */
 export type Weeklycovidadmissionsper100K = number | null;
 /**
@@ -287,6 +291,10 @@ export type Vaccinationscompletedratio = number | null;
  * Ratio of population that are fully vaccinated and have received a booster (or additional) dose.
  */
 export type Vaccinationsadditionaldoseratio = number | null;
+/**
+ * Ratio of population that have received a bivalent vaccine dose.
+ */
+export type Vaccinationsfall2022Bivalentboosterratio = number | null;
 /**
  * Risk Levels for given day
  */
@@ -308,17 +316,21 @@ export type RiskLevel = 0 | 1 | 2 | 3 | 4 | 5;
  */
 export type CDCTransmissionLevel = 0 | 1 | 2 | 3 | 4;
 /**
- * 3 digit Health Service Area identification code. For CBSA, state, and country regions hsa is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md
+ * 3 digit Health Service Area identification code. For CBSA, state, and country regions hsa is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md
  */
 export type Hsa = string | null;
 /**
- * Name of Health Service Area. For CBSA, state, and country regions hsaName is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md
+ * Name of Health Service Area. For CBSA, state, and country regions hsaName is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md
  */
 export type Hsaname = string | null;
 /**
- * Total Population of county's corresponding Health Service Area. For CBSA, state, and country regions hsaPopulation is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md
+ * Total Population of county's corresponding Health Service Area. For CBSA, state, and country regions hsaPopulation is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md
  */
 export type Hsapopulation = number | null;
+/**
+ * Community levels for any given day
+ */
+export type Communitylevels = CommunityLevelsTimeseriesRow;
 /**
  * Community level.
  */
@@ -374,7 +386,7 @@ export interface RegionTimeseriesRowWithHeader {
   hsa: Hsa;
   hsaName: Hsaname;
   hsaPopulation: Hsapopulation;
-  communityLevels?: CommunityLevelsTimeseriesRow | null;
+  communityLevels: Communitylevels;
 }
 /**
  * Known actuals data.
@@ -395,6 +407,7 @@ export interface Actuals {
   vaccinationsInitiated?: Vaccinationsinitiated;
   vaccinationsCompleted?: Vaccinationscompleted;
   vaccinationsAdditionalDose?: Vaccinationsadditionaldose;
+  vaccinationsFall2022BivalentBooster?: Vaccinationsfall2022Bivalentbooster;
   vaccinesAdministered?: Vaccinesadministered;
   vaccinesAdministeredDemographics?: Vaccinesadministereddemographics;
   vaccinationsInitiatedDemographics?: Vaccinationsinitiateddemographics;
@@ -448,6 +461,7 @@ export interface Metrics {
   vaccinationsInitiatedRatio?: Vaccinationsinitiatedratio;
   vaccinationsCompletedRatio?: Vaccinationscompletedratio;
   vaccinationsAdditionalDoseRatio?: Vaccinationsadditionaldoseratio;
+  vaccinationsFall2022BivalentBoosterRatio?: Vaccinationsfall2022Bivalentboosterratio;
 }
 /**
  * Details about how the test positivity ratio was calculated.
@@ -463,7 +477,7 @@ export interface TestPositivityRatioDetails {
  */
 export interface RiskLevelsRow {
   /**
-   * Overall risk level for region .
+   * Overall risk level for region.
    */
   overall: RiskLevel;
   /**
@@ -486,13 +500,15 @@ export interface CommunityLevelsTimeseriesRow {
    *
    * See https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html
    * for details about how the Community Level is calculated and should be
-   * interpretted.
+   * interpreted.
    *
    * Note that we provide two versions of the Community Level. One is called
-   * canCommunityLevel which is calculated on a daily basis using CAN's data
-   * sources and is available for states, counties, and metros.  The other is
-   * called cdcCommunityLevel and is the raw Community Level published by the
-   * CDC. It is only available for counties, and updates on a weekly basis.
+   * canCommunityLevel which is calculated using CAN's data sources and is
+   * available for states, counties, and metros. It is updated daily though
+   * depends on hospital data which may only update weekly for counties. The
+   * other is called cdcCommunityLevel and is the raw Community Level published
+   * by the CDC. It is only available for counties and is updated on a weekly
+   * basis.
    *
    */
   cdcCommunityLevel: CommunityLevel;
@@ -508,13 +524,15 @@ export interface CommunityLevelsTimeseriesRow {
    *
    * See https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html
    * for details about how the Community Level is calculated and should be
-   * interpretted.
+   * interpreted.
    *
    * Note that we provide two versions of the Community Level. One is called
-   * canCommunityLevel which is calculated on a daily basis using CAN's data
-   * sources and is available for states, counties, and metros.  The other is
-   * called cdcCommunityLevel and is the raw Community Level published by the
-   * CDC. It is only available for counties, and updates on a weekly basis.
+   * canCommunityLevel which is calculated using CAN's data sources and is
+   * available for states, counties, and metros. It is updated daily though
+   * depends on hospital data which may only update weekly for counties. The
+   * other is called cdcCommunityLevel and is the raw Community Level published
+   * by the CDC. It is only available for counties and is updated on a weekly
+   * basis.
    *
    */
   canCommunityLevel: CommunityLevel;

--- a/src/api/schema/AggregateRegionSummary.d.ts
+++ b/src/api/schema/AggregateRegionSummary.d.ts
@@ -21,11 +21,11 @@ export type State = string | null;
  */
 export type County = string | null;
 /**
- * 3 digit Health Service Area identification code. For CBSA, state, and country regions hsa is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md
+ * 3 digit Health Service Area identification code. For CBSA, state, and country regions hsa is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md
  */
 export type Hsa = string | null;
 /**
- * Name of Health Service Area. For CBSA, state, and country regions hsaName is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md
+ * Name of Health Service Area. For CBSA, state, and country regions hsaName is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md
  */
 export type Hsaname = string | null;
 /**
@@ -55,7 +55,7 @@ export type Long = number | null;
  */
 export type Population = number;
 /**
- * Total Population of county's corresponding Health Service Area. For CBSA, state, and country regions hsaPopulation is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md
+ * Total Population of county's corresponding Health Service Area. For CBSA, state, and country regions hsaPopulation is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md
  */
 export type Hsapopulation = number | null;
 /**
@@ -97,11 +97,11 @@ export type Infectionrateci90 = number | null;
  */
 export type Icucapacityratio = number | null;
 /**
- * Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area.
+ * Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas
  */
 export type Bedswithcovidpatientsratio = number | null;
 /**
- * Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area.
+ * Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas
  */
 export type Weeklycovidadmissionsper100K = number | null;
 /**
@@ -116,6 +116,10 @@ export type Vaccinationscompletedratio = number | null;
  * Ratio of population that are fully vaccinated and have received a booster (or additional) dose.
  */
 export type Vaccinationsadditionaldoseratio = number | null;
+/**
+ * Ratio of population that have received a bivalent vaccine dose.
+ */
+export type Vaccinationsfall2022Bivalentboosterratio = number | null;
 /**
  * Risk levels for region.
  */
@@ -192,7 +196,7 @@ export type Weeklycovidadmissions = number | null;
  *
  * Information about acute bed utilization details aggregated for the county's corresponding
  * Health Service Area (HSA). For CBSA, state, and country regions these fields are omitted.
- * For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
+ * For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
  *
  * Fields:
  *  * capacity - Current staffed acute bed capacity.
@@ -229,7 +233,7 @@ export type Currentusagecovid1 = number | null;
  *
  * Information about ICU bed utilization details aggregated for the county's corresponding
  * Health Service Area (HSA). For CBSA, state, and country regions these fields are omitted.
- * For For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
+ * For For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
  *
  * Fields:
  *  * capacity - Current staffed ICU bed capacity.
@@ -301,6 +305,10 @@ export type Vaccinationscompleted = number | null;
  * Number of individuals who are fully vaccinated and have received a booster (or additional) dose.
  */
 export type Vaccinationsadditionaldose = number | null;
+/**
+ * Number of individuals who have received a bivalent vaccine dose.
+ */
+export type Vaccinationsfall2022Bivalentbooster = number | null;
 /**
  * Total number of vaccine doses administered.
  */
@@ -436,6 +444,10 @@ export type Vaccinationscompleted1 = FieldAnnotations;
  */
 export type Vaccinationsadditionaldose1 = FieldAnnotations;
 /**
+ * Annotations for vaccinationsFall2022BivalentBooster
+ */
+export type Vaccinationsfall2022Bivalentbooster1 = FieldAnnotations;
+/**
  * Annotations for vaccinesAdministered
  */
 export type Vaccinesadministered1 = FieldAnnotations;
@@ -484,9 +496,13 @@ export type Vaccinationsinitiatedratio1 = FieldAnnotations;
  */
 export type Vaccinationscompletedratio1 = FieldAnnotations;
 /**
- * Ratio of population that are fully vaccinated and have received a booster (or additional) dose.
+ * Annotations for vaccinationsAdditionalDoseRatio
  */
 export type Vaccinationsadditionaldoseratio1 = FieldAnnotations;
+/**
+ * Annotations for vaccinationsFall2022BivalentBoosterRatio.
+ */
+export type Vaccinationsfall2022Bivalentboosterratio1 = FieldAnnotations;
 /**
  * Date of latest data
  */
@@ -568,6 +584,7 @@ export interface Metrics {
   vaccinationsInitiatedRatio?: Vaccinationsinitiatedratio;
   vaccinationsCompletedRatio?: Vaccinationscompletedratio;
   vaccinationsAdditionalDoseRatio?: Vaccinationsadditionaldoseratio;
+  vaccinationsFall2022BivalentBoosterRatio?: Vaccinationsfall2022Bivalentboosterratio;
 }
 /**
  * Details about how the test positivity ratio was calculated.
@@ -622,13 +639,15 @@ export interface CommunityLevels {
    *
    * See https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html
    * for details about how the Community Level is calculated and should be
-   * interpretted.
+   * interpreted.
    *
    * Note that we provide two versions of the Community Level. One is called
-   * canCommunityLevel which is calculated on a daily basis using CAN's data
-   * sources and is available for states, counties, and metros.  The other is
-   * called cdcCommunityLevel and is the raw Community Level published by the
-   * CDC. It is only available for counties, and updates on a weekly basis.
+   * canCommunityLevel which is calculated using CAN's data sources and is
+   * available for states, counties, and metros. It is updated daily though
+   * depends on hospital data which may only update weekly for counties. The
+   * other is called cdcCommunityLevel and is the raw Community Level published
+   * by the CDC. It is only available for counties and is updated on a weekly
+   * basis.
    *
    */
   cdcCommunityLevel: CommunityLevel;
@@ -644,13 +663,15 @@ export interface CommunityLevels {
    *
    * See https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html
    * for details about how the Community Level is calculated and should be
-   * interpretted.
+   * interpreted.
    *
    * Note that we provide two versions of the Community Level. One is called
-   * canCommunityLevel which is calculated on a daily basis using CAN's data
-   * sources and is available for states, counties, and metros.  The other is
-   * called cdcCommunityLevel and is the raw Community Level published by the
-   * CDC. It is only available for counties, and updates on a weekly basis.
+   * canCommunityLevel which is calculated using CAN's data sources and is
+   * available for states, counties, and metros. It is updated daily though
+   * depends on hospital data which may only update weekly for counties. The
+   * other is called cdcCommunityLevel and is the raw Community Level published
+   * by the CDC. It is only available for counties and is updated on a weekly
+   * basis.
    *
    */
   canCommunityLevel: CommunityLevel;
@@ -674,6 +695,7 @@ export interface Actuals {
   vaccinationsInitiated?: Vaccinationsinitiated;
   vaccinationsCompleted?: Vaccinationscompleted;
   vaccinationsAdditionalDose?: Vaccinationsadditionaldose;
+  vaccinationsFall2022BivalentBooster?: Vaccinationsfall2022Bivalentbooster;
   vaccinesAdministered?: Vaccinesadministered;
   vaccinesAdministeredDemographics?: Vaccinesadministereddemographics;
   vaccinationsInitiatedDemographics?: Vaccinationsinitiateddemographics;
@@ -729,6 +751,7 @@ export interface Annotations {
   vaccinationsInitiated?: Vaccinationsinitiated1;
   vaccinationsCompleted?: Vaccinationscompleted1;
   vaccinationsAdditionalDose?: Vaccinationsadditionaldose1;
+  vaccinationsFall2022BivalentBooster?: Vaccinationsfall2022Bivalentbooster1;
   vaccinesAdministered?: Vaccinesadministered1;
   testPositivityRatio?: Testpositivityratio1;
   caseDensity?: Casedensity1;
@@ -742,6 +765,7 @@ export interface Annotations {
   vaccinationsInitiatedRatio?: Vaccinationsinitiatedratio1;
   vaccinationsCompletedRatio?: Vaccinationscompletedratio1;
   vaccinationsAdditionalDoseRatio?: Vaccinationsadditionaldoseratio1;
+  vaccinationsFall2022BivalentBoosterRatio?: Vaccinationsfall2022Bivalentboosterratio1;
 }
 /**
  * Annotations associated with one field.

--- a/src/api/schema/AggregateRegionSummaryWithTimeseries.d.ts
+++ b/src/api/schema/AggregateRegionSummaryWithTimeseries.d.ts
@@ -21,11 +21,11 @@ export type State = string | null;
  */
 export type County = string | null;
 /**
- * 3 digit Health Service Area identification code. For CBSA, state, and country regions hsa is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md
+ * 3 digit Health Service Area identification code. For CBSA, state, and country regions hsa is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md
  */
 export type Hsa = string | null;
 /**
- * Name of Health Service Area. For CBSA, state, and country regions hsaName is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md
+ * Name of Health Service Area. For CBSA, state, and country regions hsaName is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md
  */
 export type Hsaname = string | null;
 /**
@@ -55,7 +55,7 @@ export type Long = number | null;
  */
 export type Population = number;
 /**
- * Total Population of county's corresponding Health Service Area. For CBSA, state, and country regions hsaPopulation is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md
+ * Total Population of county's corresponding Health Service Area. For CBSA, state, and country regions hsaPopulation is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md
  */
 export type Hsapopulation = number | null;
 /**
@@ -97,11 +97,11 @@ export type Infectionrateci90 = number | null;
  */
 export type Icucapacityratio = number | null;
 /**
- * Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area.
+ * Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas
  */
 export type Bedswithcovidpatientsratio = number | null;
 /**
- * Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area.
+ * Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas
  */
 export type Weeklycovidadmissionsper100K = number | null;
 /**
@@ -116,6 +116,10 @@ export type Vaccinationscompletedratio = number | null;
  * Ratio of population that are fully vaccinated and have received a booster (or additional) dose.
  */
 export type Vaccinationsadditionaldoseratio = number | null;
+/**
+ * Ratio of population that have received a bivalent vaccine dose.
+ */
+export type Vaccinationsfall2022Bivalentboosterratio = number | null;
 /**
  * Risk levels for region.
  */
@@ -192,7 +196,7 @@ export type Weeklycovidadmissions = number | null;
  *
  * Information about acute bed utilization details aggregated for the county's corresponding
  * Health Service Area (HSA). For CBSA, state, and country regions these fields are omitted.
- * For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
+ * For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
  *
  * Fields:
  *  * capacity - Current staffed acute bed capacity.
@@ -229,7 +233,7 @@ export type Currentusagecovid1 = number | null;
  *
  * Information about ICU bed utilization details aggregated for the county's corresponding
  * Health Service Area (HSA). For CBSA, state, and country regions these fields are omitted.
- * For For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
+ * For For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
  *
  * Fields:
  *  * capacity - Current staffed ICU bed capacity.
@@ -301,6 +305,10 @@ export type Vaccinationscompleted = number | null;
  * Number of individuals who are fully vaccinated and have received a booster (or additional) dose.
  */
 export type Vaccinationsadditionaldose = number | null;
+/**
+ * Number of individuals who have received a bivalent vaccine dose.
+ */
+export type Vaccinationsfall2022Bivalentbooster = number | null;
 /**
  * Total number of vaccine doses administered.
  */
@@ -436,6 +444,10 @@ export type Vaccinationscompleted1 = FieldAnnotations;
  */
 export type Vaccinationsadditionaldose1 = FieldAnnotations;
 /**
+ * Annotations for vaccinationsFall2022BivalentBooster
+ */
+export type Vaccinationsfall2022Bivalentbooster1 = FieldAnnotations;
+/**
  * Annotations for vaccinesAdministered
  */
 export type Vaccinesadministered1 = FieldAnnotations;
@@ -484,9 +496,13 @@ export type Vaccinationsinitiatedratio1 = FieldAnnotations;
  */
 export type Vaccinationscompletedratio1 = FieldAnnotations;
 /**
- * Ratio of population that are fully vaccinated and have received a booster (or additional) dose.
+ * Annotations for vaccinationsAdditionalDoseRatio
  */
 export type Vaccinationsadditionaldoseratio1 = FieldAnnotations;
+/**
+ * Annotations for vaccinationsFall2022BivalentBoosterRatio.
+ */
+export type Vaccinationsfall2022Bivalentboosterratio1 = FieldAnnotations;
 /**
  * Date of latest data
  */
@@ -524,11 +540,11 @@ export type Infectionrateci902 = number | null;
  */
 export type Icucapacityratio2 = number | null;
 /**
- * Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area.
+ * Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas
  */
 export type Bedswithcovidpatientsratio2 = number | null;
 /**
- * Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area.
+ * Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas
  */
 export type Weeklycovidadmissionsper100K2 = number | null;
 /**
@@ -543,6 +559,10 @@ export type Vaccinationscompletedratio2 = number | null;
  * Ratio of population that are fully vaccinated and have received a booster (or additional) dose.
  */
 export type Vaccinationsadditionaldoseratio2 = number | null;
+/**
+ * Ratio of population that have received a bivalent vaccine dose.
+ */
+export type Vaccinationsfall2022Bivalentboosterratio2 = number | null;
 /**
  * Date of timeseries data point
  */
@@ -584,7 +604,7 @@ export type Hospitalbeds2 = HospitalResourceUtilizationWithAdmissions;
  *
  * Information about acute bed utilization details aggregated for the county's corresponding
  * Health Service Area (HSA). For CBSA, state, and country regions these fields are omitted.
- * For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
+ * For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
  *
  * Fields:
  *  * capacity - Current staffed acute bed capacity.
@@ -609,7 +629,7 @@ export type Icubeds2 = HospitalResourceUtilization;
  *
  * Information about ICU bed utilization details aggregated for the county's corresponding
  * Health Service Area (HSA). For CBSA, state, and country regions these fields are omitted.
- * For For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
+ * For For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
  *
  * Fields:
  *  * capacity - Current staffed ICU bed capacity.
@@ -681,6 +701,10 @@ export type Vaccinationscompleted2 = number | null;
  * Number of individuals who are fully vaccinated and have received a booster (or additional) dose.
  */
 export type Vaccinationsadditionaldose2 = number | null;
+/**
+ * Number of individuals who have received a bivalent vaccine dose.
+ */
+export type Vaccinationsfall2022Bivalentbooster2 = number | null;
 /**
  * Total number of vaccine doses administered.
  */
@@ -791,6 +815,7 @@ export interface Metrics {
   vaccinationsInitiatedRatio?: Vaccinationsinitiatedratio;
   vaccinationsCompletedRatio?: Vaccinationscompletedratio;
   vaccinationsAdditionalDoseRatio?: Vaccinationsadditionaldoseratio;
+  vaccinationsFall2022BivalentBoosterRatio?: Vaccinationsfall2022Bivalentboosterratio;
 }
 /**
  * Details about how the test positivity ratio was calculated.
@@ -845,13 +870,15 @@ export interface CommunityLevels {
    *
    * See https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html
    * for details about how the Community Level is calculated and should be
-   * interpretted.
+   * interpreted.
    *
    * Note that we provide two versions of the Community Level. One is called
-   * canCommunityLevel which is calculated on a daily basis using CAN's data
-   * sources and is available for states, counties, and metros.  The other is
-   * called cdcCommunityLevel and is the raw Community Level published by the
-   * CDC. It is only available for counties, and updates on a weekly basis.
+   * canCommunityLevel which is calculated using CAN's data sources and is
+   * available for states, counties, and metros. It is updated daily though
+   * depends on hospital data which may only update weekly for counties. The
+   * other is called cdcCommunityLevel and is the raw Community Level published
+   * by the CDC. It is only available for counties and is updated on a weekly
+   * basis.
    *
    */
   cdcCommunityLevel: CommunityLevel;
@@ -867,13 +894,15 @@ export interface CommunityLevels {
    *
    * See https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html
    * for details about how the Community Level is calculated and should be
-   * interpretted.
+   * interpreted.
    *
    * Note that we provide two versions of the Community Level. One is called
-   * canCommunityLevel which is calculated on a daily basis using CAN's data
-   * sources and is available for states, counties, and metros.  The other is
-   * called cdcCommunityLevel and is the raw Community Level published by the
-   * CDC. It is only available for counties, and updates on a weekly basis.
+   * canCommunityLevel which is calculated using CAN's data sources and is
+   * available for states, counties, and metros. It is updated daily though
+   * depends on hospital data which may only update weekly for counties. The
+   * other is called cdcCommunityLevel and is the raw Community Level published
+   * by the CDC. It is only available for counties and is updated on a weekly
+   * basis.
    *
    */
   canCommunityLevel: CommunityLevel;
@@ -897,6 +926,7 @@ export interface Actuals {
   vaccinationsInitiated?: Vaccinationsinitiated;
   vaccinationsCompleted?: Vaccinationscompleted;
   vaccinationsAdditionalDose?: Vaccinationsadditionaldose;
+  vaccinationsFall2022BivalentBooster?: Vaccinationsfall2022Bivalentbooster;
   vaccinesAdministered?: Vaccinesadministered;
   vaccinesAdministeredDemographics?: Vaccinesadministereddemographics;
   vaccinationsInitiatedDemographics?: Vaccinationsinitiateddemographics;
@@ -952,6 +982,7 @@ export interface Annotations {
   vaccinationsInitiated?: Vaccinationsinitiated1;
   vaccinationsCompleted?: Vaccinationscompleted1;
   vaccinationsAdditionalDose?: Vaccinationsadditionaldose1;
+  vaccinationsFall2022BivalentBooster?: Vaccinationsfall2022Bivalentbooster1;
   vaccinesAdministered?: Vaccinesadministered1;
   testPositivityRatio?: Testpositivityratio1;
   caseDensity?: Casedensity1;
@@ -965,6 +996,7 @@ export interface Annotations {
   vaccinationsInitiatedRatio?: Vaccinationsinitiatedratio1;
   vaccinationsCompletedRatio?: Vaccinationscompletedratio1;
   vaccinationsAdditionalDoseRatio?: Vaccinationsadditionaldoseratio1;
+  vaccinationsFall2022BivalentBoosterRatio?: Vaccinationsfall2022Bivalentboosterratio1;
 }
 /**
  * Annotations associated with one field.
@@ -1012,6 +1044,7 @@ export interface MetricsTimeseriesRow {
   vaccinationsInitiatedRatio?: Vaccinationsinitiatedratio2;
   vaccinationsCompletedRatio?: Vaccinationscompletedratio2;
   vaccinationsAdditionalDoseRatio?: Vaccinationsadditionaldoseratio2;
+  vaccinationsFall2022BivalentBoosterRatio?: Vaccinationsfall2022Bivalentboosterratio2;
   date: Date1;
 }
 /**
@@ -1033,6 +1066,7 @@ export interface ActualsTimeseriesRow {
   vaccinationsInitiated?: Vaccinationsinitiated2;
   vaccinationsCompleted?: Vaccinationscompleted2;
   vaccinationsAdditionalDose?: Vaccinationsadditionaldose2;
+  vaccinationsFall2022BivalentBooster?: Vaccinationsfall2022Bivalentbooster2;
   vaccinesAdministered?: Vaccinesadministered2;
   vaccinesAdministeredDemographics?: Vaccinesadministereddemographics1;
   vaccinationsInitiatedDemographics?: Vaccinationsinitiateddemographics1;
@@ -1043,7 +1077,7 @@ export interface ActualsTimeseriesRow {
  */
 export interface RiskLevelTimeseriesRow {
   /**
-   * Overall risk level for region .
+   * Overall risk level for region.
    */
   overall: RiskLevel;
   /**
@@ -1097,13 +1131,15 @@ export interface CommunityLevelsTimeseriesRow {
    *
    * See https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html
    * for details about how the Community Level is calculated and should be
-   * interpretted.
+   * interpreted.
    *
    * Note that we provide two versions of the Community Level. One is called
-   * canCommunityLevel which is calculated on a daily basis using CAN's data
-   * sources and is available for states, counties, and metros.  The other is
-   * called cdcCommunityLevel and is the raw Community Level published by the
-   * CDC. It is only available for counties, and updates on a weekly basis.
+   * canCommunityLevel which is calculated using CAN's data sources and is
+   * available for states, counties, and metros. It is updated daily though
+   * depends on hospital data which may only update weekly for counties. The
+   * other is called cdcCommunityLevel and is the raw Community Level published
+   * by the CDC. It is only available for counties and is updated on a weekly
+   * basis.
    *
    */
   cdcCommunityLevel: CommunityLevel;
@@ -1119,13 +1155,15 @@ export interface CommunityLevelsTimeseriesRow {
    *
    * See https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html
    * for details about how the Community Level is calculated and should be
-   * interpretted.
+   * interpreted.
    *
    * Note that we provide two versions of the Community Level. One is called
-   * canCommunityLevel which is calculated on a daily basis using CAN's data
-   * sources and is available for states, counties, and metros.  The other is
-   * called cdcCommunityLevel and is the raw Community Level published by the
-   * CDC. It is only available for counties, and updates on a weekly basis.
+   * canCommunityLevel which is calculated using CAN's data sources and is
+   * available for states, counties, and metros. It is updated daily though
+   * depends on hospital data which may only update weekly for counties. The
+   * other is called cdcCommunityLevel and is the raw Community Level published
+   * by the CDC. It is only available for counties and is updated on a weekly
+   * basis.
    *
    */
   canCommunityLevel: CommunityLevel;

--- a/src/api/schema/Metrics.d.ts
+++ b/src/api/schema/Metrics.d.ts
@@ -43,11 +43,11 @@ export type Infectionrateci90 = number | null;
  */
 export type Icucapacityratio = number | null;
 /**
- * Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area.
+ * Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas
  */
 export type Bedswithcovidpatientsratio = number | null;
 /**
- * Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area.
+ * Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas
  */
 export type Weeklycovidadmissionsper100K = number | null;
 /**
@@ -62,6 +62,10 @@ export type Vaccinationscompletedratio = number | null;
  * Ratio of population that are fully vaccinated and have received a booster (or additional) dose.
  */
 export type Vaccinationsadditionaldoseratio = number | null;
+/**
+ * Ratio of population that have received a bivalent vaccine dose.
+ */
+export type Vaccinationsfall2022Bivalentboosterratio = number | null;
 
 /**
  * Calculated metrics data based on known actuals.
@@ -80,6 +84,7 @@ export interface Metrics {
   vaccinationsInitiatedRatio?: Vaccinationsinitiatedratio;
   vaccinationsCompletedRatio?: Vaccinationscompletedratio;
   vaccinationsAdditionalDoseRatio?: Vaccinationsadditionaldoseratio;
+  vaccinationsFall2022BivalentBoosterRatio?: Vaccinationsfall2022Bivalentboosterratio;
 }
 /**
  * Details about how the test positivity ratio was calculated.

--- a/src/api/schema/MetricsTimeseriesRow.d.ts
+++ b/src/api/schema/MetricsTimeseriesRow.d.ts
@@ -43,11 +43,11 @@ export type Infectionrateci90 = number | null;
  */
 export type Icucapacityratio = number | null;
 /**
- * Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area.
+ * Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas
  */
 export type Bedswithcovidpatientsratio = number | null;
 /**
- * Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area.
+ * Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas
  */
 export type Weeklycovidadmissionsper100K = number | null;
 /**
@@ -62,6 +62,10 @@ export type Vaccinationscompletedratio = number | null;
  * Ratio of population that are fully vaccinated and have received a booster (or additional) dose.
  */
 export type Vaccinationsadditionaldoseratio = number | null;
+/**
+ * Ratio of population that have received a bivalent vaccine dose.
+ */
+export type Vaccinationsfall2022Bivalentboosterratio = number | null;
 /**
  * Date of timeseries data point
  */
@@ -84,6 +88,7 @@ export interface MetricsTimeseriesRow {
   vaccinationsInitiatedRatio?: Vaccinationsinitiatedratio;
   vaccinationsCompletedRatio?: Vaccinationscompletedratio;
   vaccinationsAdditionalDoseRatio?: Vaccinationsadditionaldoseratio;
+  vaccinationsFall2022BivalentBoosterRatio?: Vaccinationsfall2022Bivalentboosterratio;
   date: Date;
 }
 /**

--- a/src/api/schema/RegionSummary.d.ts
+++ b/src/api/schema/RegionSummary.d.ts
@@ -21,11 +21,11 @@ export type State = string | null;
  */
 export type County = string | null;
 /**
- * 3 digit Health Service Area identification code. For CBSA, state, and country regions hsa is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md
+ * 3 digit Health Service Area identification code. For CBSA, state, and country regions hsa is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md
  */
 export type Hsa = string | null;
 /**
- * Name of Health Service Area. For CBSA, state, and country regions hsaName is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md
+ * Name of Health Service Area. For CBSA, state, and country regions hsaName is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md
  */
 export type Hsaname = string | null;
 /**
@@ -55,7 +55,7 @@ export type Long = number | null;
  */
 export type Population = number;
 /**
- * Total Population of county's corresponding Health Service Area. For CBSA, state, and country regions hsaPopulation is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md
+ * Total Population of county's corresponding Health Service Area. For CBSA, state, and country regions hsaPopulation is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md
  */
 export type Hsapopulation = number | null;
 /**
@@ -97,11 +97,11 @@ export type Infectionrateci90 = number | null;
  */
 export type Icucapacityratio = number | null;
 /**
- * Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area.
+ * Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas
  */
 export type Bedswithcovidpatientsratio = number | null;
 /**
- * Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area.
+ * Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas
  */
 export type Weeklycovidadmissionsper100K = number | null;
 /**
@@ -116,6 +116,10 @@ export type Vaccinationscompletedratio = number | null;
  * Ratio of population that are fully vaccinated and have received a booster (or additional) dose.
  */
 export type Vaccinationsadditionaldoseratio = number | null;
+/**
+ * Ratio of population that have received a bivalent vaccine dose.
+ */
+export type Vaccinationsfall2022Bivalentboosterratio = number | null;
 /**
  * Risk levels for region.
  */
@@ -192,7 +196,7 @@ export type Weeklycovidadmissions = number | null;
  *
  * Information about acute bed utilization details aggregated for the county's corresponding
  * Health Service Area (HSA). For CBSA, state, and country regions these fields are omitted.
- * For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
+ * For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
  *
  * Fields:
  *  * capacity - Current staffed acute bed capacity.
@@ -229,7 +233,7 @@ export type Currentusagecovid1 = number | null;
  *
  * Information about ICU bed utilization details aggregated for the county's corresponding
  * Health Service Area (HSA). For CBSA, state, and country regions these fields are omitted.
- * For For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
+ * For For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
  *
  * Fields:
  *  * capacity - Current staffed ICU bed capacity.
@@ -301,6 +305,10 @@ export type Vaccinationscompleted = number | null;
  * Number of individuals who are fully vaccinated and have received a booster (or additional) dose.
  */
 export type Vaccinationsadditionaldose = number | null;
+/**
+ * Number of individuals who have received a bivalent vaccine dose.
+ */
+export type Vaccinationsfall2022Bivalentbooster = number | null;
 /**
  * Total number of vaccine doses administered.
  */
@@ -436,6 +444,10 @@ export type Vaccinationscompleted1 = FieldAnnotations;
  */
 export type Vaccinationsadditionaldose1 = FieldAnnotations;
 /**
+ * Annotations for vaccinationsFall2022BivalentBooster
+ */
+export type Vaccinationsfall2022Bivalentbooster1 = FieldAnnotations;
+/**
  * Annotations for vaccinesAdministered
  */
 export type Vaccinesadministered1 = FieldAnnotations;
@@ -484,9 +496,13 @@ export type Vaccinationsinitiatedratio1 = FieldAnnotations;
  */
 export type Vaccinationscompletedratio1 = FieldAnnotations;
 /**
- * Ratio of population that are fully vaccinated and have received a booster (or additional) dose.
+ * Annotations for vaccinationsAdditionalDoseRatio
  */
 export type Vaccinationsadditionaldoseratio1 = FieldAnnotations;
+/**
+ * Annotations for vaccinationsFall2022BivalentBoosterRatio.
+ */
+export type Vaccinationsfall2022Bivalentboosterratio1 = FieldAnnotations;
 /**
  * Date of latest data
  */
@@ -564,6 +580,7 @@ export interface Metrics {
   vaccinationsInitiatedRatio?: Vaccinationsinitiatedratio;
   vaccinationsCompletedRatio?: Vaccinationscompletedratio;
   vaccinationsAdditionalDoseRatio?: Vaccinationsadditionaldoseratio;
+  vaccinationsFall2022BivalentBoosterRatio?: Vaccinationsfall2022Bivalentboosterratio;
 }
 /**
  * Details about how the test positivity ratio was calculated.
@@ -618,13 +635,15 @@ export interface CommunityLevels {
    *
    * See https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html
    * for details about how the Community Level is calculated and should be
-   * interpretted.
+   * interpreted.
    *
    * Note that we provide two versions of the Community Level. One is called
-   * canCommunityLevel which is calculated on a daily basis using CAN's data
-   * sources and is available for states, counties, and metros.  The other is
-   * called cdcCommunityLevel and is the raw Community Level published by the
-   * CDC. It is only available for counties, and updates on a weekly basis.
+   * canCommunityLevel which is calculated using CAN's data sources and is
+   * available for states, counties, and metros. It is updated daily though
+   * depends on hospital data which may only update weekly for counties. The
+   * other is called cdcCommunityLevel and is the raw Community Level published
+   * by the CDC. It is only available for counties and is updated on a weekly
+   * basis.
    *
    */
   cdcCommunityLevel: CommunityLevel;
@@ -640,13 +659,15 @@ export interface CommunityLevels {
    *
    * See https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html
    * for details about how the Community Level is calculated and should be
-   * interpretted.
+   * interpreted.
    *
    * Note that we provide two versions of the Community Level. One is called
-   * canCommunityLevel which is calculated on a daily basis using CAN's data
-   * sources and is available for states, counties, and metros.  The other is
-   * called cdcCommunityLevel and is the raw Community Level published by the
-   * CDC. It is only available for counties, and updates on a weekly basis.
+   * canCommunityLevel which is calculated using CAN's data sources and is
+   * available for states, counties, and metros. It is updated daily though
+   * depends on hospital data which may only update weekly for counties. The
+   * other is called cdcCommunityLevel and is the raw Community Level published
+   * by the CDC. It is only available for counties and is updated on a weekly
+   * basis.
    *
    */
   canCommunityLevel: CommunityLevel;
@@ -670,6 +691,7 @@ export interface Actuals {
   vaccinationsInitiated?: Vaccinationsinitiated;
   vaccinationsCompleted?: Vaccinationscompleted;
   vaccinationsAdditionalDose?: Vaccinationsadditionaldose;
+  vaccinationsFall2022BivalentBooster?: Vaccinationsfall2022Bivalentbooster;
   vaccinesAdministered?: Vaccinesadministered;
   vaccinesAdministeredDemographics?: Vaccinesadministereddemographics;
   vaccinationsInitiatedDemographics?: Vaccinationsinitiateddemographics;
@@ -725,6 +747,7 @@ export interface Annotations {
   vaccinationsInitiated?: Vaccinationsinitiated1;
   vaccinationsCompleted?: Vaccinationscompleted1;
   vaccinationsAdditionalDose?: Vaccinationsadditionaldose1;
+  vaccinationsFall2022BivalentBooster?: Vaccinationsfall2022Bivalentbooster1;
   vaccinesAdministered?: Vaccinesadministered1;
   testPositivityRatio?: Testpositivityratio1;
   caseDensity?: Casedensity1;
@@ -738,6 +761,7 @@ export interface Annotations {
   vaccinationsInitiatedRatio?: Vaccinationsinitiatedratio1;
   vaccinationsCompletedRatio?: Vaccinationscompletedratio1;
   vaccinationsAdditionalDoseRatio?: Vaccinationsadditionaldoseratio1;
+  vaccinationsFall2022BivalentBoosterRatio?: Vaccinationsfall2022Bivalentboosterratio1;
 }
 /**
  * Annotations associated with one field.

--- a/src/api/schema/RegionSummaryWithTimeseries.d.ts
+++ b/src/api/schema/RegionSummaryWithTimeseries.d.ts
@@ -21,11 +21,11 @@ export type State = string | null;
  */
 export type County = string | null;
 /**
- * 3 digit Health Service Area identification code. For CBSA, state, and country regions hsa is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md
+ * 3 digit Health Service Area identification code. For CBSA, state, and country regions hsa is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md
  */
 export type Hsa = string | null;
 /**
- * Name of Health Service Area. For CBSA, state, and country regions hsaName is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md
+ * Name of Health Service Area. For CBSA, state, and country regions hsaName is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md
  */
 export type Hsaname = string | null;
 /**
@@ -55,7 +55,7 @@ export type Long = number | null;
  */
 export type Population = number;
 /**
- * Total Population of county's corresponding Health Service Area. For CBSA, state, and country regions hsaPopulation is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md
+ * Total Population of county's corresponding Health Service Area. For CBSA, state, and country regions hsaPopulation is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md
  */
 export type Hsapopulation = number | null;
 /**
@@ -97,11 +97,11 @@ export type Infectionrateci90 = number | null;
  */
 export type Icucapacityratio = number | null;
 /**
- * Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area.
+ * Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas
  */
 export type Bedswithcovidpatientsratio = number | null;
 /**
- * Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area.
+ * Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas
  */
 export type Weeklycovidadmissionsper100K = number | null;
 /**
@@ -116,6 +116,10 @@ export type Vaccinationscompletedratio = number | null;
  * Ratio of population that are fully vaccinated and have received a booster (or additional) dose.
  */
 export type Vaccinationsadditionaldoseratio = number | null;
+/**
+ * Ratio of population that have received a bivalent vaccine dose.
+ */
+export type Vaccinationsfall2022Bivalentboosterratio = number | null;
 /**
  * Risk levels for region.
  */
@@ -192,7 +196,7 @@ export type Weeklycovidadmissions = number | null;
  *
  * Information about acute bed utilization details aggregated for the county's corresponding
  * Health Service Area (HSA). For CBSA, state, and country regions these fields are omitted.
- * For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
+ * For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
  *
  * Fields:
  *  * capacity - Current staffed acute bed capacity.
@@ -229,7 +233,7 @@ export type Currentusagecovid1 = number | null;
  *
  * Information about ICU bed utilization details aggregated for the county's corresponding
  * Health Service Area (HSA). For CBSA, state, and country regions these fields are omitted.
- * For For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
+ * For For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
  *
  * Fields:
  *  * capacity - Current staffed ICU bed capacity.
@@ -301,6 +305,10 @@ export type Vaccinationscompleted = number | null;
  * Number of individuals who are fully vaccinated and have received a booster (or additional) dose.
  */
 export type Vaccinationsadditionaldose = number | null;
+/**
+ * Number of individuals who have received a bivalent vaccine dose.
+ */
+export type Vaccinationsfall2022Bivalentbooster = number | null;
 /**
  * Total number of vaccine doses administered.
  */
@@ -436,6 +444,10 @@ export type Vaccinationscompleted1 = FieldAnnotations;
  */
 export type Vaccinationsadditionaldose1 = FieldAnnotations;
 /**
+ * Annotations for vaccinationsFall2022BivalentBooster
+ */
+export type Vaccinationsfall2022Bivalentbooster1 = FieldAnnotations;
+/**
  * Annotations for vaccinesAdministered
  */
 export type Vaccinesadministered1 = FieldAnnotations;
@@ -484,9 +496,13 @@ export type Vaccinationsinitiatedratio1 = FieldAnnotations;
  */
 export type Vaccinationscompletedratio1 = FieldAnnotations;
 /**
- * Ratio of population that are fully vaccinated and have received a booster (or additional) dose.
+ * Annotations for vaccinationsAdditionalDoseRatio
  */
 export type Vaccinationsadditionaldoseratio1 = FieldAnnotations;
+/**
+ * Annotations for vaccinationsFall2022BivalentBoosterRatio.
+ */
+export type Vaccinationsfall2022Bivalentboosterratio1 = FieldAnnotations;
 /**
  * Date of latest data
  */
@@ -524,11 +540,11 @@ export type Infectionrateci902 = number | null;
  */
 export type Icucapacityratio2 = number | null;
 /**
- * Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area.
+ * Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas
  */
 export type Bedswithcovidpatientsratio2 = number | null;
 /**
- * Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area.
+ * Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas
  */
 export type Weeklycovidadmissionsper100K2 = number | null;
 /**
@@ -543,6 +559,10 @@ export type Vaccinationscompletedratio2 = number | null;
  * Ratio of population that are fully vaccinated and have received a booster (or additional) dose.
  */
 export type Vaccinationsadditionaldoseratio2 = number | null;
+/**
+ * Ratio of population that have received a bivalent vaccine dose.
+ */
+export type Vaccinationsfall2022Bivalentboosterratio2 = number | null;
 /**
  * Date of timeseries data point
  */
@@ -584,7 +604,7 @@ export type Hospitalbeds2 = HospitalResourceUtilizationWithAdmissions;
  *
  * Information about acute bed utilization details aggregated for the county's corresponding
  * Health Service Area (HSA). For CBSA, state, and country regions these fields are omitted.
- * For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
+ * For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
  *
  * Fields:
  *  * capacity - Current staffed acute bed capacity.
@@ -609,7 +629,7 @@ export type Icubeds2 = HospitalResourceUtilization;
  *
  * Information about ICU bed utilization details aggregated for the county's corresponding
  * Health Service Area (HSA). For CBSA, state, and country regions these fields are omitted.
- * For For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
+ * For For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
  *
  * Fields:
  *  * capacity - Current staffed ICU bed capacity.
@@ -681,6 +701,10 @@ export type Vaccinationscompleted2 = number | null;
  * Number of individuals who are fully vaccinated and have received a booster (or additional) dose.
  */
 export type Vaccinationsadditionaldose2 = number | null;
+/**
+ * Number of individuals who have received a bivalent vaccine dose.
+ */
+export type Vaccinationsfall2022Bivalentbooster2 = number | null;
 /**
  * Total number of vaccine doses administered.
  */
@@ -787,6 +811,7 @@ export interface Metrics {
   vaccinationsInitiatedRatio?: Vaccinationsinitiatedratio;
   vaccinationsCompletedRatio?: Vaccinationscompletedratio;
   vaccinationsAdditionalDoseRatio?: Vaccinationsadditionaldoseratio;
+  vaccinationsFall2022BivalentBoosterRatio?: Vaccinationsfall2022Bivalentboosterratio;
 }
 /**
  * Details about how the test positivity ratio was calculated.
@@ -841,13 +866,15 @@ export interface CommunityLevels {
    *
    * See https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html
    * for details about how the Community Level is calculated and should be
-   * interpretted.
+   * interpreted.
    *
    * Note that we provide two versions of the Community Level. One is called
-   * canCommunityLevel which is calculated on a daily basis using CAN's data
-   * sources and is available for states, counties, and metros.  The other is
-   * called cdcCommunityLevel and is the raw Community Level published by the
-   * CDC. It is only available for counties, and updates on a weekly basis.
+   * canCommunityLevel which is calculated using CAN's data sources and is
+   * available for states, counties, and metros. It is updated daily though
+   * depends on hospital data which may only update weekly for counties. The
+   * other is called cdcCommunityLevel and is the raw Community Level published
+   * by the CDC. It is only available for counties and is updated on a weekly
+   * basis.
    *
    */
   cdcCommunityLevel: CommunityLevel;
@@ -863,13 +890,15 @@ export interface CommunityLevels {
    *
    * See https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html
    * for details about how the Community Level is calculated and should be
-   * interpretted.
+   * interpreted.
    *
    * Note that we provide two versions of the Community Level. One is called
-   * canCommunityLevel which is calculated on a daily basis using CAN's data
-   * sources and is available for states, counties, and metros.  The other is
-   * called cdcCommunityLevel and is the raw Community Level published by the
-   * CDC. It is only available for counties, and updates on a weekly basis.
+   * canCommunityLevel which is calculated using CAN's data sources and is
+   * available for states, counties, and metros. It is updated daily though
+   * depends on hospital data which may only update weekly for counties. The
+   * other is called cdcCommunityLevel and is the raw Community Level published
+   * by the CDC. It is only available for counties and is updated on a weekly
+   * basis.
    *
    */
   canCommunityLevel: CommunityLevel;
@@ -893,6 +922,7 @@ export interface Actuals {
   vaccinationsInitiated?: Vaccinationsinitiated;
   vaccinationsCompleted?: Vaccinationscompleted;
   vaccinationsAdditionalDose?: Vaccinationsadditionaldose;
+  vaccinationsFall2022BivalentBooster?: Vaccinationsfall2022Bivalentbooster;
   vaccinesAdministered?: Vaccinesadministered;
   vaccinesAdministeredDemographics?: Vaccinesadministereddemographics;
   vaccinationsInitiatedDemographics?: Vaccinationsinitiateddemographics;
@@ -948,6 +978,7 @@ export interface Annotations {
   vaccinationsInitiated?: Vaccinationsinitiated1;
   vaccinationsCompleted?: Vaccinationscompleted1;
   vaccinationsAdditionalDose?: Vaccinationsadditionaldose1;
+  vaccinationsFall2022BivalentBooster?: Vaccinationsfall2022Bivalentbooster1;
   vaccinesAdministered?: Vaccinesadministered1;
   testPositivityRatio?: Testpositivityratio1;
   caseDensity?: Casedensity1;
@@ -961,6 +992,7 @@ export interface Annotations {
   vaccinationsInitiatedRatio?: Vaccinationsinitiatedratio1;
   vaccinationsCompletedRatio?: Vaccinationscompletedratio1;
   vaccinationsAdditionalDoseRatio?: Vaccinationsadditionaldoseratio1;
+  vaccinationsFall2022BivalentBoosterRatio?: Vaccinationsfall2022Bivalentboosterratio1;
 }
 /**
  * Annotations associated with one field.
@@ -1008,6 +1040,7 @@ export interface MetricsTimeseriesRow {
   vaccinationsInitiatedRatio?: Vaccinationsinitiatedratio2;
   vaccinationsCompletedRatio?: Vaccinationscompletedratio2;
   vaccinationsAdditionalDoseRatio?: Vaccinationsadditionaldoseratio2;
+  vaccinationsFall2022BivalentBoosterRatio?: Vaccinationsfall2022Bivalentboosterratio2;
   date: Date1;
 }
 /**
@@ -1029,6 +1062,7 @@ export interface ActualsTimeseriesRow {
   vaccinationsInitiated?: Vaccinationsinitiated2;
   vaccinationsCompleted?: Vaccinationscompleted2;
   vaccinationsAdditionalDose?: Vaccinationsadditionaldose2;
+  vaccinationsFall2022BivalentBooster?: Vaccinationsfall2022Bivalentbooster2;
   vaccinesAdministered?: Vaccinesadministered2;
   vaccinesAdministeredDemographics?: Vaccinesadministereddemographics1;
   vaccinationsInitiatedDemographics?: Vaccinationsinitiateddemographics1;
@@ -1039,7 +1073,7 @@ export interface ActualsTimeseriesRow {
  */
 export interface RiskLevelTimeseriesRow {
   /**
-   * Overall risk level for region .
+   * Overall risk level for region.
    */
   overall: RiskLevel;
   /**
@@ -1093,13 +1127,15 @@ export interface CommunityLevelsTimeseriesRow {
    *
    * See https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html
    * for details about how the Community Level is calculated and should be
-   * interpretted.
+   * interpreted.
    *
    * Note that we provide two versions of the Community Level. One is called
-   * canCommunityLevel which is calculated on a daily basis using CAN's data
-   * sources and is available for states, counties, and metros.  The other is
-   * called cdcCommunityLevel and is the raw Community Level published by the
-   * CDC. It is only available for counties, and updates on a weekly basis.
+   * canCommunityLevel which is calculated using CAN's data sources and is
+   * available for states, counties, and metros. It is updated daily though
+   * depends on hospital data which may only update weekly for counties. The
+   * other is called cdcCommunityLevel and is the raw Community Level published
+   * by the CDC. It is only available for counties and is updated on a weekly
+   * basis.
    *
    */
   cdcCommunityLevel: CommunityLevel;
@@ -1115,13 +1151,15 @@ export interface CommunityLevelsTimeseriesRow {
    *
    * See https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html
    * for details about how the Community Level is calculated and should be
-   * interpretted.
+   * interpreted.
    *
    * Note that we provide two versions of the Community Level. One is called
-   * canCommunityLevel which is calculated on a daily basis using CAN's data
-   * sources and is available for states, counties, and metros.  The other is
-   * called cdcCommunityLevel and is the raw Community Level published by the
-   * CDC. It is only available for counties, and updates on a weekly basis.
+   * canCommunityLevel which is calculated using CAN's data sources and is
+   * available for states, counties, and metros. It is updated daily though
+   * depends on hospital data which may only update weekly for counties. The
+   * other is called cdcCommunityLevel and is the raw Community Level published
+   * by the CDC. It is only available for counties and is updated on a weekly
+   * basis.
    *
    */
   canCommunityLevel: CommunityLevel;

--- a/src/screens/HomePage/HomePage.tsx
+++ b/src/screens/HomePage/HomePage.tsx
@@ -2,7 +2,6 @@ import React, { useRef, useEffect, useState, useMemo } from 'react';
 import Fade from '@material-ui/core/Fade';
 import { useLocation } from 'react-router-dom';
 import USRiskMap from 'components/USMap/USRiskMap';
-import USVaccineMap from 'components/USMap/USVaccineMap';
 import { NavBarSearch } from 'components/NavBar';
 import { NavAllOtherPages } from 'components/NavBar';
 import AppMetaTags from 'components/AppMetaTags/AppMetaTags';
@@ -10,7 +9,7 @@ import EnsureSharingIdInUrl from 'components/EnsureSharingIdInUrl';
 import PartnersSection from 'components/PartnersSection/PartnersSection';
 import CompareMain from 'components/Compare/CompareMain';
 import Explore, { ExploreMetric } from 'components/Explore';
-import { formatMetatagDate, formatPercent } from 'common/utils';
+import { formatMetatagDate } from 'common/utils';
 import { getFilterLimit } from 'components/Search';
 import HomepageStructuredData from 'screens/HomePage/HomepageStructuredData';
 import { filterGeolocatedRegions } from 'common/regions';
@@ -24,22 +23,16 @@ import {
   Content,
   HomePageBlock,
   ColumnCentered,
-  VaccinationsThermometerHeading,
-  AboutLink,
   MapDescriptionText,
+  AboutLink,
 } from './HomePage.style';
 import SearchAutocomplete from 'components/Search';
-import {
-  CommunityLevelThermometer,
-  VaccinationsThermometer,
-} from 'components/HorizontalThermometer';
+import { CommunityLevelThermometer } from 'components/HorizontalThermometer';
 import HomepageItems from 'components/RegionItem/HomepageItems';
 import { useBreakpoint, useFinalAutocompleteLocations } from 'common/hooks';
 import { largestMetroFipsForExplore, MapView } from 'screens/HomePage/utils';
 import { DonateButtonHeart } from 'components/DonateButton';
-import SiteSummaryJSON from 'assets/data/site-summary.json';
 import { MapBlock } from './MapBlock';
-import { TooltipMode } from 'components/USMap/USMapTooltip';
 import NationalText from 'components/NationalText';
 import Recommendations from 'components/Recommend/Recommendations';
 import regions, { USA } from 'common/regions';
@@ -91,7 +84,6 @@ export default function HomePage() {
   const searchLocations = useFinalAutocompleteLocations();
 
   const isMobileNavBar = useBreakpoint(800);
-  const isMobile = useBreakpoint(600);
   const hasScrolled = useShowPastPosition(450);
   const showDonateButton = !isMobileNavBar || (isMobileNavBar && !hasScrolled);
   const renderNavBarSearch = () => (
@@ -160,36 +152,6 @@ export default function HomePage() {
               }
               mapDescription={getRiskMapDescription()}
             />
-
-            <MapBlock
-              title="Vaccination Progress"
-              subtitle={getVaccinationProgressSubtitle()}
-              renderMap={locationScope => (
-                <USVaccineMap
-                  showCounties={locationScope === MapView.COUNTIES}
-                  tooltipMode={
-                    // TODO(michael): There's some sort of bug / performance issue on iOS that makes
-                    // the mobile tooltip on the county view unusable.
-                    isMobile && locationScope === MapView.STATES
-                      ? TooltipMode.ACTIVATE_ON_CLICK
-                      : TooltipMode.ACTIVATE_ON_HOVER
-                  }
-                />
-              )}
-              renderThermometer={() => (
-                <>
-                  <VaccinationsThermometerHeading>
-                    Population with <b>1+ dose</b>
-                  </VaccinationsThermometerHeading>
-                  <VaccinationsThermometer />
-                </>
-              )}
-              infoLink={
-                <AboutLink to="/covid-community-level-metrics#percent-vaccinated">
-                  About this data
-                </AboutLink>
-              }
-            />
             <HomePageBlock
               ref={exploreSectionRef}
               id="explore-hospitalizations"
@@ -224,19 +186,6 @@ export default function HomePage() {
           </Content>
         </div>
       </main>
-    </>
-  );
-}
-
-function getVaccinationProgressSubtitle() {
-  const { totalVaccinationsInitiated, totalPopulation } = SiteSummaryJSON.usa;
-  const percentVaccinated = formatPercent(
-    totalVaccinationsInitiated / totalPopulation,
-  );
-  return (
-    <>
-      <b>{percentVaccinated}</b> of the entire U.S. population has received{' '}
-      <b>1+ dose</b>.
     </>
   );
 }


### PR DESCRIPTION
Removes Vx map and pulls in bivalent vaccination types from backend API

From roadmap in [CAN cleanup sprint planner](https://docs.google.com/document/d/1kN9Gn7hYzD70SRgXk4IdVkMR5F9GpDpmQIZUwjHBOO0/edit): This was lower in the priority list, but it was a quick change and will remove some extra potential complexity when adding new bivalent booster data and changing the priority/focus from 1+ to bivalent. 

This leaves the Vx map components and tooltips intact, just removes them from the homepage. There's a world in which we remove them entirely, but a) maybe we'll want these components in the future and b) it would require a fair amount of cleanup. I'm open to arguments that we should do that cleanup now, though