### PR TITLE
Revert "Remove Vx Map from homepage and update API types (#7142)"

### DIFF
--- a/src/api/schema/Actuals.d.ts
+++ b/src/api/schema/Actuals.d.ts
@@ -56,7 +56,7 @@ export type Weeklycovidadmissions = number | null;
  *
  * Information about acute bed utilization details aggregated for the county's corresponding
  * Health Service Area (HSA). For CBSA, state, and country regions these fields are omitted.
- * For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
+ * For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
  *
  * Fields:
  *  * capacity - Current staffed acute bed capacity.
@@ -93,7 +93,7 @@ export type Currentusagecovid1 = number | null;
  *
  * Information about ICU bed utilization details aggregated for the county's corresponding
  * Health Service Area (HSA). For CBSA, state, and country regions these fields are omitted.
- * For For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
+ * For For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
  *
  * Fields:
  *  * capacity - Current staffed ICU bed capacity.
@@ -166,10 +166,6 @@ export type Vaccinationscompleted = number | null;
  */
 export type Vaccinationsadditionaldose = number | null;
 /**
- * Number of individuals who have received a bivalent vaccine dose.
- */
-export type Vaccinationsfall2022Bivalentbooster = number | null;
-/**
  * Total number of vaccine doses administered.
  */
 export type Vaccinesadministered = number | null;
@@ -213,7 +209,6 @@ export interface Actuals {
   vaccinationsInitiated?: Vaccinationsinitiated;
   vaccinationsCompleted?: Vaccinationscompleted;
   vaccinationsAdditionalDose?: Vaccinationsadditionaldose;
-  vaccinationsFall2022BivalentBooster?: Vaccinationsfall2022Bivalentbooster;
   vaccinesAdministered?: Vaccinesadministered;
   vaccinesAdministeredDemographics?: Vaccinesadministereddemographics;
   vaccinationsInitiatedDemographics?: Vaccinationsinitiateddemographics;

--- a/src/api/schema/ActualsTimeseriesRow.d.ts
+++ b/src/api/schema/ActualsTimeseriesRow.d.ts
@@ -56,7 +56,7 @@ export type Weeklycovidadmissions = number | null;
  *
  * Information about acute bed utilization details aggregated for the county's corresponding
  * Health Service Area (HSA). For CBSA, state, and country regions these fields are omitted.
- * For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
+ * For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
  *
  * Fields:
  *  * capacity - Current staffed acute bed capacity.
@@ -93,7 +93,7 @@ export type Currentusagecovid1 = number | null;
  *
  * Information about ICU bed utilization details aggregated for the county's corresponding
  * Health Service Area (HSA). For CBSA, state, and country regions these fields are omitted.
- * For For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
+ * For For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
  *
  * Fields:
  *  * capacity - Current staffed ICU bed capacity.
@@ -166,10 +166,6 @@ export type Vaccinationscompleted = number | null;
  */
 export type Vaccinationsadditionaldose = number | null;
 /**
- * Number of individuals who have received a bivalent vaccine dose.
- */
-export type Vaccinationsfall2022Bivalentbooster = number | null;
-/**
  * Total number of vaccine doses administered.
  */
 export type Vaccinesadministered = number | null;
@@ -217,7 +213,6 @@ export interface ActualsTimeseriesRow {
   vaccinationsInitiated?: Vaccinationsinitiated;
   vaccinationsCompleted?: Vaccinationscompleted;
   vaccinationsAdditionalDose?: Vaccinationsadditionaldose;
-  vaccinationsFall2022BivalentBooster?: Vaccinationsfall2022Bivalentbooster;
   vaccinesAdministered?: Vaccinesadministered;
   vaccinesAdministeredDemographics?: Vaccinesadministereddemographics;
   vaccinationsInitiatedDemographics?: Vaccinationsinitiateddemographics;

--- a/src/api/schema/AggregateFlattenedTimeseries.d.ts
+++ b/src/api/schema/AggregateFlattenedTimeseries.d.ts
@@ -92,7 +92,7 @@ export type Weeklycovidadmissions = number | null;
  *
  * Information about acute bed utilization details aggregated for the county's corresponding
  * Health Service Area (HSA). For CBSA, state, and country regions these fields are omitted.
- * For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
+ * For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
  *
  * Fields:
  *  * capacity - Current staffed acute bed capacity.
@@ -129,7 +129,7 @@ export type Currentusagecovid1 = number | null;
  *
  * Information about ICU bed utilization details aggregated for the county's corresponding
  * Health Service Area (HSA). For CBSA, state, and country regions these fields are omitted.
- * For For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
+ * For For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
  *
  * Fields:
  *  * capacity - Current staffed ICU bed capacity.
@@ -202,10 +202,6 @@ export type Vaccinationscompleted = number | null;
  */
 export type Vaccinationsadditionaldose = number | null;
 /**
- * Number of individuals who have received a bivalent vaccine dose.
- */
-export type Vaccinationsfall2022Bivalentbooster = number | null;
-/**
  * Total number of vaccine doses administered.
  */
 export type Vaccinesadministered = number | null;
@@ -272,11 +268,11 @@ export type Infectionrateci90 = number | null;
  */
 export type Icucapacityratio = number | null;
 /**
- * Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas
+ * Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area.
  */
 export type Bedswithcovidpatientsratio = number | null;
 /**
- * Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas
+ * Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area.
  */
 export type Weeklycovidadmissionsper100K = number | null;
 /**
@@ -291,10 +287,6 @@ export type Vaccinationscompletedratio = number | null;
  * Ratio of population that are fully vaccinated and have received a booster (or additional) dose.
  */
 export type Vaccinationsadditionaldoseratio = number | null;
-/**
- * Ratio of population that have received a bivalent vaccine dose.
- */
-export type Vaccinationsfall2022Bivalentboosterratio = number | null;
 /**
  * Risk Levels for given day
  */
@@ -316,21 +308,17 @@ export type RiskLevel = 0 | 1 | 2 | 3 | 4 | 5;
  */
 export type CDCTransmissionLevel = 0 | 1 | 2 | 3 | 4;
 /**
- * 3 digit Health Service Area identification code. For CBSA, state, and country regions hsa is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md
+ * 3 digit Health Service Area identification code. For CBSA, state, and country regions hsa is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md
  */
 export type Hsa = string | null;
 /**
- * Name of Health Service Area. For CBSA, state, and country regions hsaName is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md
+ * Name of Health Service Area. For CBSA, state, and country regions hsaName is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md
  */
 export type Hsaname = string | null;
 /**
- * Total Population of county's corresponding Health Service Area. For CBSA, state, and country regions hsaPopulation is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md
+ * Total Population of county's corresponding Health Service Area. For CBSA, state, and country regions hsaPopulation is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md
  */
 export type Hsapopulation = number | null;
-/**
- * Community levels for any given day
- */
-export type Communitylevels = CommunityLevelsTimeseriesRow;
 /**
  * Community level.
  */
@@ -386,7 +374,7 @@ export interface RegionTimeseriesRowWithHeader {
   hsa: Hsa;
   hsaName: Hsaname;
   hsaPopulation: Hsapopulation;
-  communityLevels: Communitylevels;
+  communityLevels?: CommunityLevelsTimeseriesRow | null;
 }
 /**
  * Known actuals data.
@@ -407,7 +395,6 @@ export interface Actuals {
   vaccinationsInitiated?: Vaccinationsinitiated;
   vaccinationsCompleted?: Vaccinationscompleted;
   vaccinationsAdditionalDose?: Vaccinationsadditionaldose;
-  vaccinationsFall2022BivalentBooster?: Vaccinationsfall2022Bivalentbooster;
   vaccinesAdministered?: Vaccinesadministered;
   vaccinesAdministeredDemographics?: Vaccinesadministereddemographics;
   vaccinationsInitiatedDemographics?: Vaccinationsinitiateddemographics;
@@ -461,7 +448,6 @@ export interface Metrics {
   vaccinationsInitiatedRatio?: Vaccinationsinitiatedratio;
   vaccinationsCompletedRatio?: Vaccinationscompletedratio;
   vaccinationsAdditionalDoseRatio?: Vaccinationsadditionaldoseratio;
-  vaccinationsFall2022BivalentBoosterRatio?: Vaccinationsfall2022Bivalentboosterratio;
 }
 /**
  * Details about how the test positivity ratio was calculated.
@@ -477,7 +463,7 @@ export interface TestPositivityRatioDetails {
  */
 export interface RiskLevelsRow {
   /**
-   * Overall risk level for region.
+   * Overall risk level for region .
    */
   overall: RiskLevel;
   /**
@@ -500,15 +486,13 @@ export interface CommunityLevelsTimeseriesRow {
    *
    * See https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html
    * for details about how the Community Level is calculated and should be
-   * interpreted.
+   * interpretted.
    *
    * Note that we provide two versions of the Community Level. One is called
-   * canCommunityLevel which is calculated using CAN's data sources and is
-   * available for states, counties, and metros. It is updated daily though
-   * depends on hospital data which may only update weekly for counties. The
-   * other is called cdcCommunityLevel and is the raw Community Level published
-   * by the CDC. It is only available for counties and is updated on a weekly
-   * basis.
+   * canCommunityLevel which is calculated on a daily basis using CAN's data
+   * sources and is available for states, counties, and metros.  The other is
+   * called cdcCommunityLevel and is the raw Community Level published by the
+   * CDC. It is only available for counties, and updates on a weekly basis.
    *
    */
   cdcCommunityLevel: CommunityLevel;
@@ -524,15 +508,13 @@ export interface CommunityLevelsTimeseriesRow {
    *
    * See https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html
    * for details about how the Community Level is calculated and should be
-   * interpreted.
+   * interpretted.
    *
    * Note that we provide two versions of the Community Level. One is called
-   * canCommunityLevel which is calculated using CAN's data sources and is
-   * available for states, counties, and metros. It is updated daily though
-   * depends on hospital data which may only update weekly for counties. The
-   * other is called cdcCommunityLevel and is the raw Community Level published
-   * by the CDC. It is only available for counties and is updated on a weekly
-   * basis.
+   * canCommunityLevel which is calculated on a daily basis using CAN's data
+   * sources and is available for states, counties, and metros.  The other is
+   * called cdcCommunityLevel and is the raw Community Level published by the
+   * CDC. It is only available for counties, and updates on a weekly basis.
    *
    */
   canCommunityLevel: CommunityLevel;

--- a/src/api/schema/AggregateRegionSummary.d.ts
+++ b/src/api/schema/AggregateRegionSummary.d.ts
@@ -21,11 +21,11 @@ export type State = string | null;
  */
 export type County = string | null;
 /**
- * 3 digit Health Service Area identification code. For CBSA, state, and country regions hsa is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md
+ * 3 digit Health Service Area identification code. For CBSA, state, and country regions hsa is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md
  */
 export type Hsa = string | null;
 /**
- * Name of Health Service Area. For CBSA, state, and country regions hsaName is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md
+ * Name of Health Service Area. For CBSA, state, and country regions hsaName is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md
  */
 export type Hsaname = string | null;
 /**
@@ -55,7 +55,7 @@ export type Long = number | null;
  */
 export type Population = number;
 /**
- * Total Population of county's corresponding Health Service Area. For CBSA, state, and country regions hsaPopulation is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md
+ * Total Population of county's corresponding Health Service Area. For CBSA, state, and country regions hsaPopulation is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md
  */
 export type Hsapopulation = number | null;
 /**
@@ -97,11 +97,11 @@ export type Infectionrateci90 = number | null;
  */
 export type Icucapacityratio = number | null;
 /**
- * Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas
+ * Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area.
  */
 export type Bedswithcovidpatientsratio = number | null;
 /**
- * Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas
+ * Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area.
  */
 export type Weeklycovidadmissionsper100K = number | null;
 /**
@@ -116,10 +116,6 @@ export type Vaccinationscompletedratio = number | null;
  * Ratio of population that are fully vaccinated and have received a booster (or additional) dose.
  */
 export type Vaccinationsadditionaldoseratio = number | null;
-/**
- * Ratio of population that have received a bivalent vaccine dose.
- */
-export type Vaccinationsfall2022Bivalentboosterratio = number | null;
 /**
  * Risk levels for region.
  */
@@ -196,7 +192,7 @@ export type Weeklycovidadmissions = number | null;
  *
  * Information about acute bed utilization details aggregated for the county's corresponding
  * Health Service Area (HSA). For CBSA, state, and country regions these fields are omitted.
- * For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
+ * For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
  *
  * Fields:
  *  * capacity - Current staffed acute bed capacity.
@@ -233,7 +229,7 @@ export type Currentusagecovid1 = number | null;
  *
  * Information about ICU bed utilization details aggregated for the county's corresponding
  * Health Service Area (HSA). For CBSA, state, and country regions these fields are omitted.
- * For For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
+ * For For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
  *
  * Fields:
  *  * capacity - Current staffed ICU bed capacity.
@@ -305,10 +301,6 @@ export type Vaccinationscompleted = number | null;
  * Number of individuals who are fully vaccinated and have received a booster (or additional) dose.
  */
 export type Vaccinationsadditionaldose = number | null;
-/**
- * Number of individuals who have received a bivalent vaccine dose.
- */
-export type Vaccinationsfall2022Bivalentbooster = number | null;
 /**
  * Total number of vaccine doses administered.
  */
@@ -444,10 +436,6 @@ export type Vaccinationscompleted1 = FieldAnnotations;
  */
 export type Vaccinationsadditionaldose1 = FieldAnnotations;
 /**
- * Annotations for vaccinationsFall2022BivalentBooster
- */
-export type Vaccinationsfall2022Bivalentbooster1 = FieldAnnotations;
-/**
  * Annotations for vaccinesAdministered
  */
 export type Vaccinesadministered1 = FieldAnnotations;
@@ -496,13 +484,9 @@ export type Vaccinationsinitiatedratio1 = FieldAnnotations;
  */
 export type Vaccinationscompletedratio1 = FieldAnnotations;
 /**
- * Annotations for vaccinationsAdditionalDoseRatio
+ * Ratio of population that are fully vaccinated and have received a booster (or additional) dose.
  */
 export type Vaccinationsadditionaldoseratio1 = FieldAnnotations;
-/**
- * Annotations for vaccinationsFall2022BivalentBoosterRatio.
- */
-export type Vaccinationsfall2022Bivalentboosterratio1 = FieldAnnotations;
 /**
  * Date of latest data
  */
@@ -584,7 +568,6 @@ export interface Metrics {
   vaccinationsInitiatedRatio?: Vaccinationsinitiatedratio;
   vaccinationsCompletedRatio?: Vaccinationscompletedratio;
   vaccinationsAdditionalDoseRatio?: Vaccinationsadditionaldoseratio;
-  vaccinationsFall2022BivalentBoosterRatio?: Vaccinationsfall2022Bivalentboosterratio;
 }
 /**
  * Details about how the test positivity ratio was calculated.
@@ -639,15 +622,13 @@ export interface CommunityLevels {
    *
    * See https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html
    * for details about how the Community Level is calculated and should be
-   * interpreted.
+   * interpretted.
    *
    * Note that we provide two versions of the Community Level. One is called
-   * canCommunityLevel which is calculated using CAN's data sources and is
-   * available for states, counties, and metros. It is updated daily though
-   * depends on hospital data which may only update weekly for counties. The
-   * other is called cdcCommunityLevel and is the raw Community Level published
-   * by the CDC. It is only available for counties and is updated on a weekly
-   * basis.
+   * canCommunityLevel which is calculated on a daily basis using CAN's data
+   * sources and is available for states, counties, and metros.  The other is
+   * called cdcCommunityLevel and is the raw Community Level published by the
+   * CDC. It is only available for counties, and updates on a weekly basis.
    *
    */
   cdcCommunityLevel: CommunityLevel;
@@ -663,15 +644,13 @@ export interface CommunityLevels {
    *
    * See https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html
    * for details about how the Community Level is calculated and should be
-   * interpreted.
+   * interpretted.
    *
    * Note that we provide two versions of the Community Level. One is called
-   * canCommunityLevel which is calculated using CAN's data sources and is
-   * available for states, counties, and metros. It is updated daily though
-   * depends on hospital data which may only update weekly for counties. The
-   * other is called cdcCommunityLevel and is the raw Community Level published
-   * by the CDC. It is only available for counties and is updated on a weekly
-   * basis.
+   * canCommunityLevel which is calculated on a daily basis using CAN's data
+   * sources and is available for states, counties, and metros.  The other is
+   * called cdcCommunityLevel and is the raw Community Level published by the
+   * CDC. It is only available for counties, and updates on a weekly basis.
    *
    */
   canCommunityLevel: CommunityLevel;
@@ -695,7 +674,6 @@ export interface Actuals {
   vaccinationsInitiated?: Vaccinationsinitiated;
   vaccinationsCompleted?: Vaccinationscompleted;
   vaccinationsAdditionalDose?: Vaccinationsadditionaldose;
-  vaccinationsFall2022BivalentBooster?: Vaccinationsfall2022Bivalentbooster;
   vaccinesAdministered?: Vaccinesadministered;
   vaccinesAdministeredDemographics?: Vaccinesadministereddemographics;
   vaccinationsInitiatedDemographics?: Vaccinationsinitiateddemographics;
@@ -751,7 +729,6 @@ export interface Annotations {
   vaccinationsInitiated?: Vaccinationsinitiated1;
   vaccinationsCompleted?: Vaccinationscompleted1;
   vaccinationsAdditionalDose?: Vaccinationsadditionaldose1;
-  vaccinationsFall2022BivalentBooster?: Vaccinationsfall2022Bivalentbooster1;
   vaccinesAdministered?: Vaccinesadministered1;
   testPositivityRatio?: Testpositivityratio1;
   caseDensity?: Casedensity1;
@@ -765,7 +742,6 @@ export interface Annotations {
   vaccinationsInitiatedRatio?: Vaccinationsinitiatedratio1;
   vaccinationsCompletedRatio?: Vaccinationscompletedratio1;
   vaccinationsAdditionalDoseRatio?: Vaccinationsadditionaldoseratio1;
-  vaccinationsFall2022BivalentBoosterRatio?: Vaccinationsfall2022Bivalentboosterratio1;
 }
 /**
  * Annotations associated with one field.

--- a/src/api/schema/AggregateRegionSummaryWithTimeseries.d.ts
+++ b/src/api/schema/AggregateRegionSummaryWithTimeseries.d.ts
@@ -21,11 +21,11 @@ export type State = string | null;
  */
 export type County = string | null;
 /**
- * 3 digit Health Service Area identification code. For CBSA, state, and country regions hsa is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md
+ * 3 digit Health Service Area identification code. For CBSA, state, and country regions hsa is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md
  */
 export type Hsa = string | null;
 /**
- * Name of Health Service Area. For CBSA, state, and country regions hsaName is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md
+ * Name of Health Service Area. For CBSA, state, and country regions hsaName is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md
  */
 export type Hsaname = string | null;
 /**
@@ -55,7 +55,7 @@ export type Long = number | null;
  */
 export type Population = number;
 /**
- * Total Population of county's corresponding Health Service Area. For CBSA, state, and country regions hsaPopulation is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md
+ * Total Population of county's corresponding Health Service Area. For CBSA, state, and country regions hsaPopulation is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md
  */
 export type Hsapopulation = number | null;
 /**
@@ -97,11 +97,11 @@ export type Infectionrateci90 = number | null;
  */
 export type Icucapacityratio = number | null;
 /**
- * Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas
+ * Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area.
  */
 export type Bedswithcovidpatientsratio = number | null;
 /**
- * Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas
+ * Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area.
  */
 export type Weeklycovidadmissionsper100K = number | null;
 /**
@@ -116,10 +116,6 @@ export type Vaccinationscompletedratio = number | null;
  * Ratio of population that are fully vaccinated and have received a booster (or additional) dose.
  */
 export type Vaccinationsadditionaldoseratio = number | null;
-/**
- * Ratio of population that have received a bivalent vaccine dose.
- */
-export type Vaccinationsfall2022Bivalentboosterratio = number | null;
 /**
  * Risk levels for region.
  */
@@ -196,7 +192,7 @@ export type Weeklycovidadmissions = number | null;
  *
  * Information about acute bed utilization details aggregated for the county's corresponding
  * Health Service Area (HSA). For CBSA, state, and country regions these fields are omitted.
- * For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
+ * For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
  *
  * Fields:
  *  * capacity - Current staffed acute bed capacity.
@@ -233,7 +229,7 @@ export type Currentusagecovid1 = number | null;
  *
  * Information about ICU bed utilization details aggregated for the county's corresponding
  * Health Service Area (HSA). For CBSA, state, and country regions these fields are omitted.
- * For For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
+ * For For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
  *
  * Fields:
  *  * capacity - Current staffed ICU bed capacity.
@@ -305,10 +301,6 @@ export type Vaccinationscompleted = number | null;
  * Number of individuals who are fully vaccinated and have received a booster (or additional) dose.
  */
 export type Vaccinationsadditionaldose = number | null;
-/**
- * Number of individuals who have received a bivalent vaccine dose.
- */
-export type Vaccinationsfall2022Bivalentbooster = number | null;
 /**
  * Total number of vaccine doses administered.
  */
@@ -444,10 +436,6 @@ export type Vaccinationscompleted1 = FieldAnnotations;
  */
 export type Vaccinationsadditionaldose1 = FieldAnnotations;
 /**
- * Annotations for vaccinationsFall2022BivalentBooster
- */
-export type Vaccinationsfall2022Bivalentbooster1 = FieldAnnotations;
-/**
  * Annotations for vaccinesAdministered
  */
 export type Vaccinesadministered1 = FieldAnnotations;
@@ -496,13 +484,9 @@ export type Vaccinationsinitiatedratio1 = FieldAnnotations;
  */
 export type Vaccinationscompletedratio1 = FieldAnnotations;
 /**
- * Annotations for vaccinationsAdditionalDoseRatio
+ * Ratio of population that are fully vaccinated and have received a booster (or additional) dose.
  */
 export type Vaccinationsadditionaldoseratio1 = FieldAnnotations;
-/**
- * Annotations for vaccinationsFall2022BivalentBoosterRatio.
- */
-export type Vaccinationsfall2022Bivalentboosterratio1 = FieldAnnotations;
 /**
  * Date of latest data
  */
@@ -540,11 +524,11 @@ export type Infectionrateci902 = number | null;
  */
 export type Icucapacityratio2 = number | null;
 /**
- * Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas
+ * Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area.
  */
 export type Bedswithcovidpatientsratio2 = number | null;
 /**
- * Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas
+ * Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area.
  */
 export type Weeklycovidadmissionsper100K2 = number | null;
 /**
@@ -559,10 +543,6 @@ export type Vaccinationscompletedratio2 = number | null;
  * Ratio of population that are fully vaccinated and have received a booster (or additional) dose.
  */
 export type Vaccinationsadditionaldoseratio2 = number | null;
-/**
- * Ratio of population that have received a bivalent vaccine dose.
- */
-export type Vaccinationsfall2022Bivalentboosterratio2 = number | null;
 /**
  * Date of timeseries data point
  */
@@ -604,7 +584,7 @@ export type Hospitalbeds2 = HospitalResourceUtilizationWithAdmissions;
  *
  * Information about acute bed utilization details aggregated for the county's corresponding
  * Health Service Area (HSA). For CBSA, state, and country regions these fields are omitted.
- * For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
+ * For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
  *
  * Fields:
  *  * capacity - Current staffed acute bed capacity.
@@ -629,7 +609,7 @@ export type Icubeds2 = HospitalResourceUtilization;
  *
  * Information about ICU bed utilization details aggregated for the county's corresponding
  * Health Service Area (HSA). For CBSA, state, and country regions these fields are omitted.
- * For For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
+ * For For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
  *
  * Fields:
  *  * capacity - Current staffed ICU bed capacity.
@@ -701,10 +681,6 @@ export type Vaccinationscompleted2 = number | null;
  * Number of individuals who are fully vaccinated and have received a booster (or additional) dose.
  */
 export type Vaccinationsadditionaldose2 = number | null;
-/**
- * Number of individuals who have received a bivalent vaccine dose.
- */
-export type Vaccinationsfall2022Bivalentbooster2 = number | null;
 /**
  * Total number of vaccine doses administered.
  */
@@ -815,7 +791,6 @@ export interface Metrics {
   vaccinationsInitiatedRatio?: Vaccinationsinitiatedratio;
   vaccinationsCompletedRatio?: Vaccinationscompletedratio;
   vaccinationsAdditionalDoseRatio?: Vaccinationsadditionaldoseratio;
-  vaccinationsFall2022BivalentBoosterRatio?: Vaccinationsfall2022Bivalentboosterratio;
 }
 /**
  * Details about how the test positivity ratio was calculated.
@@ -870,15 +845,13 @@ export interface CommunityLevels {
    *
    * See https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html
    * for details about how the Community Level is calculated and should be
-   * interpreted.
+   * interpretted.
    *
    * Note that we provide two versions of the Community Level. One is called
-   * canCommunityLevel which is calculated using CAN's data sources and is
-   * available for states, counties, and metros. It is updated daily though
-   * depends on hospital data which may only update weekly for counties. The
-   * other is called cdcCommunityLevel and is the raw Community Level published
-   * by the CDC. It is only available for counties and is updated on a weekly
-   * basis.
+   * canCommunityLevel which is calculated on a daily basis using CAN's data
+   * sources and is available for states, counties, and metros.  The other is
+   * called cdcCommunityLevel and is the raw Community Level published by the
+   * CDC. It is only available for counties, and updates on a weekly basis.
    *
    */
   cdcCommunityLevel: CommunityLevel;
@@ -894,15 +867,13 @@ export interface CommunityLevels {
    *
    * See https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html
    * for details about how the Community Level is calculated and should be
-   * interpreted.
+   * interpretted.
    *
    * Note that we provide two versions of the Community Level. One is called
-   * canCommunityLevel which is calculated using CAN's data sources and is
-   * available for states, counties, and metros. It is updated daily though
-   * depends on hospital data which may only update weekly for counties. The
-   * other is called cdcCommunityLevel and is the raw Community Level published
-   * by the CDC. It is only available for counties and is updated on a weekly
-   * basis.
+   * canCommunityLevel which is calculated on a daily basis using CAN's data
+   * sources and is available for states, counties, and metros.  The other is
+   * called cdcCommunityLevel and is the raw Community Level published by the
+   * CDC. It is only available for counties, and updates on a weekly basis.
    *
    */
   canCommunityLevel: CommunityLevel;
@@ -926,7 +897,6 @@ export interface Actuals {
   vaccinationsInitiated?: Vaccinationsinitiated;
   vaccinationsCompleted?: Vaccinationscompleted;
   vaccinationsAdditionalDose?: Vaccinationsadditionaldose;
-  vaccinationsFall2022BivalentBooster?: Vaccinationsfall2022Bivalentbooster;
   vaccinesAdministered?: Vaccinesadministered;
   vaccinesAdministeredDemographics?: Vaccinesadministereddemographics;
   vaccinationsInitiatedDemographics?: Vaccinationsinitiateddemographics;
@@ -982,7 +952,6 @@ export interface Annotations {
   vaccinationsInitiated?: Vaccinationsinitiated1;
   vaccinationsCompleted?: Vaccinationscompleted1;
   vaccinationsAdditionalDose?: Vaccinationsadditionaldose1;
-  vaccinationsFall2022BivalentBooster?: Vaccinationsfall2022Bivalentbooster1;
   vaccinesAdministered?: Vaccinesadministered1;
   testPositivityRatio?: Testpositivityratio1;
   caseDensity?: Casedensity1;
@@ -996,7 +965,6 @@ export interface Annotations {
   vaccinationsInitiatedRatio?: Vaccinationsinitiatedratio1;
   vaccinationsCompletedRatio?: Vaccinationscompletedratio1;
   vaccinationsAdditionalDoseRatio?: Vaccinationsadditionaldoseratio1;
-  vaccinationsFall2022BivalentBoosterRatio?: Vaccinationsfall2022Bivalentboosterratio1;
 }
 /**
  * Annotations associated with one field.
@@ -1044,7 +1012,6 @@ export interface MetricsTimeseriesRow {
   vaccinationsInitiatedRatio?: Vaccinationsinitiatedratio2;
   vaccinationsCompletedRatio?: Vaccinationscompletedratio2;
   vaccinationsAdditionalDoseRatio?: Vaccinationsadditionaldoseratio2;
-  vaccinationsFall2022BivalentBoosterRatio?: Vaccinationsfall2022Bivalentboosterratio2;
   date: Date1;
 }
 /**
@@ -1066,7 +1033,6 @@ export interface ActualsTimeseriesRow {
   vaccinationsInitiated?: Vaccinationsinitiated2;
   vaccinationsCompleted?: Vaccinationscompleted2;
   vaccinationsAdditionalDose?: Vaccinationsadditionaldose2;
-  vaccinationsFall2022BivalentBooster?: Vaccinationsfall2022Bivalentbooster2;
   vaccinesAdministered?: Vaccinesadministered2;
   vaccinesAdministeredDemographics?: Vaccinesadministereddemographics1;
   vaccinationsInitiatedDemographics?: Vaccinationsinitiateddemographics1;
@@ -1077,7 +1043,7 @@ export interface ActualsTimeseriesRow {
  */
 export interface RiskLevelTimeseriesRow {
   /**
-   * Overall risk level for region.
+   * Overall risk level for region .
    */
   overall: RiskLevel;
   /**
@@ -1131,15 +1097,13 @@ export interface CommunityLevelsTimeseriesRow {
    *
    * See https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html
    * for details about how the Community Level is calculated and should be
-   * interpreted.
+   * interpretted.
    *
    * Note that we provide two versions of the Community Level. One is called
-   * canCommunityLevel which is calculated using CAN's data sources and is
-   * available for states, counties, and metros. It is updated daily though
-   * depends on hospital data which may only update weekly for counties. The
-   * other is called cdcCommunityLevel and is the raw Community Level published
-   * by the CDC. It is only available for counties and is updated on a weekly
-   * basis.
+   * canCommunityLevel which is calculated on a daily basis using CAN's data
+   * sources and is available for states, counties, and metros.  The other is
+   * called cdcCommunityLevel and is the raw Community Level published by the
+   * CDC. It is only available for counties, and updates on a weekly basis.
    *
    */
   cdcCommunityLevel: CommunityLevel;
@@ -1155,15 +1119,13 @@ export interface CommunityLevelsTimeseriesRow {
    *
    * See https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html
    * for details about how the Community Level is calculated and should be
-   * interpreted.
+   * interpretted.
    *
    * Note that we provide two versions of the Community Level. One is called
-   * canCommunityLevel which is calculated using CAN's data sources and is
-   * available for states, counties, and metros. It is updated daily though
-   * depends on hospital data which may only update weekly for counties. The
-   * other is called cdcCommunityLevel and is the raw Community Level published
-   * by the CDC. It is only available for counties and is updated on a weekly
-   * basis.
+   * canCommunityLevel which is calculated on a daily basis using CAN's data
+   * sources and is available for states, counties, and metros.  The other is
+   * called cdcCommunityLevel and is the raw Community Level published by the
+   * CDC. It is only available for counties, and updates on a weekly basis.
    *
    */
   canCommunityLevel: CommunityLevel;

--- a/src/api/schema/Metrics.d.ts
+++ b/src/api/schema/Metrics.d.ts
@@ -43,11 +43,11 @@ export type Infectionrateci90 = number | null;
  */
 export type Icucapacityratio = number | null;
 /**
- * Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas
+ * Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area.
  */
 export type Bedswithcovidpatientsratio = number | null;
 /**
- * Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas
+ * Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area.
  */
 export type Weeklycovidadmissionsper100K = number | null;
 /**
@@ -62,10 +62,6 @@ export type Vaccinationscompletedratio = number | null;
  * Ratio of population that are fully vaccinated and have received a booster (or additional) dose.
  */
 export type Vaccinationsadditionaldoseratio = number | null;
-/**
- * Ratio of population that have received a bivalent vaccine dose.
- */
-export type Vaccinationsfall2022Bivalentboosterratio = number | null;
 
 /**
  * Calculated metrics data based on known actuals.
@@ -84,7 +80,6 @@ export interface Metrics {
   vaccinationsInitiatedRatio?: Vaccinationsinitiatedratio;
   vaccinationsCompletedRatio?: Vaccinationscompletedratio;
   vaccinationsAdditionalDoseRatio?: Vaccinationsadditionaldoseratio;
-  vaccinationsFall2022BivalentBoosterRatio?: Vaccinationsfall2022Bivalentboosterratio;
 }
 /**
  * Details about how the test positivity ratio was calculated.

--- a/src/api/schema/MetricsTimeseriesRow.d.ts
+++ b/src/api/schema/MetricsTimeseriesRow.d.ts
@@ -43,11 +43,11 @@ export type Infectionrateci90 = number | null;
  */
 export type Icucapacityratio = number | null;
 /**
- * Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas
+ * Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area.
  */
 export type Bedswithcovidpatientsratio = number | null;
 /**
- * Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas
+ * Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area.
  */
 export type Weeklycovidadmissionsper100K = number | null;
 /**
@@ -62,10 +62,6 @@ export type Vaccinationscompletedratio = number | null;
  * Ratio of population that are fully vaccinated and have received a booster (or additional) dose.
  */
 export type Vaccinationsadditionaldoseratio = number | null;
-/**
- * Ratio of population that have received a bivalent vaccine dose.
- */
-export type Vaccinationsfall2022Bivalentboosterratio = number | null;
 /**
  * Date of timeseries data point
  */
@@ -88,7 +84,6 @@ export interface MetricsTimeseriesRow {
   vaccinationsInitiatedRatio?: Vaccinationsinitiatedratio;
   vaccinationsCompletedRatio?: Vaccinationscompletedratio;
   vaccinationsAdditionalDoseRatio?: Vaccinationsadditionaldoseratio;
-  vaccinationsFall2022BivalentBoosterRatio?: Vaccinationsfall2022Bivalentboosterratio;
   date: Date;
 }
 /**

--- a/src/api/schema/RegionSummary.d.ts
+++ b/src/api/schema/RegionSummary.d.ts
@@ -21,11 +21,11 @@ export type State = string | null;
  */
 export type County = string | null;
 /**
- * 3 digit Health Service Area identification code. For CBSA, state, and country regions hsa is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md
+ * 3 digit Health Service Area identification code. For CBSA, state, and country regions hsa is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md
  */
 export type Hsa = string | null;
 /**
- * Name of Health Service Area. For CBSA, state, and country regions hsaName is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md
+ * Name of Health Service Area. For CBSA, state, and country regions hsaName is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md
  */
 export type Hsaname = string | null;
 /**
@@ -55,7 +55,7 @@ export type Long = number | null;
  */
 export type Population = number;
 /**
- * Total Population of county's corresponding Health Service Area. For CBSA, state, and country regions hsaPopulation is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md
+ * Total Population of county's corresponding Health Service Area. For CBSA, state, and country regions hsaPopulation is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md
  */
 export type Hsapopulation = number | null;
 /**
@@ -97,11 +97,11 @@ export type Infectionrateci90 = number | null;
  */
 export type Icucapacityratio = number | null;
 /**
- * Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas
+ * Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area.
  */
 export type Bedswithcovidpatientsratio = number | null;
 /**
- * Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas
+ * Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area.
  */
 export type Weeklycovidadmissionsper100K = number | null;
 /**
@@ -116,10 +116,6 @@ export type Vaccinationscompletedratio = number | null;
  * Ratio of population that are fully vaccinated and have received a booster (or additional) dose.
  */
 export type Vaccinationsadditionaldoseratio = number | null;
-/**
- * Ratio of population that have received a bivalent vaccine dose.
- */
-export type Vaccinationsfall2022Bivalentboosterratio = number | null;
 /**
  * Risk levels for region.
  */
@@ -196,7 +192,7 @@ export type Weeklycovidadmissions = number | null;
  *
  * Information about acute bed utilization details aggregated for the county's corresponding
  * Health Service Area (HSA). For CBSA, state, and country regions these fields are omitted.
- * For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
+ * For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
  *
  * Fields:
  *  * capacity - Current staffed acute bed capacity.
@@ -233,7 +229,7 @@ export type Currentusagecovid1 = number | null;
  *
  * Information about ICU bed utilization details aggregated for the county's corresponding
  * Health Service Area (HSA). For CBSA, state, and country regions these fields are omitted.
- * For For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
+ * For For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
  *
  * Fields:
  *  * capacity - Current staffed ICU bed capacity.
@@ -305,10 +301,6 @@ export type Vaccinationscompleted = number | null;
  * Number of individuals who are fully vaccinated and have received a booster (or additional) dose.
  */
 export type Vaccinationsadditionaldose = number | null;
-/**
- * Number of individuals who have received a bivalent vaccine dose.
- */
-export type Vaccinationsfall2022Bivalentbooster = number | null;
 /**
  * Total number of vaccine doses administered.
  */
@@ -444,10 +436,6 @@ export type Vaccinationscompleted1 = FieldAnnotations;
  */
 export type Vaccinationsadditionaldose1 = FieldAnnotations;
 /**
- * Annotations for vaccinationsFall2022BivalentBooster
- */
-export type Vaccinationsfall2022Bivalentbooster1 = FieldAnnotations;
-/**
  * Annotations for vaccinesAdministered
  */
 export type Vaccinesadministered1 = FieldAnnotations;
@@ -496,13 +484,9 @@ export type Vaccinationsinitiatedratio1 = FieldAnnotations;
  */
 export type Vaccinationscompletedratio1 = FieldAnnotations;
 /**
- * Annotations for vaccinationsAdditionalDoseRatio
+ * Ratio of population that are fully vaccinated and have received a booster (or additional) dose.
  */
 export type Vaccinationsadditionaldoseratio1 = FieldAnnotations;
-/**
- * Annotations for vaccinationsFall2022BivalentBoosterRatio.
- */
-export type Vaccinationsfall2022Bivalentboosterratio1 = FieldAnnotations;
 /**
  * Date of latest data
  */
@@ -580,7 +564,6 @@ export interface Metrics {
   vaccinationsInitiatedRatio?: Vaccinationsinitiatedratio;
   vaccinationsCompletedRatio?: Vaccinationscompletedratio;
   vaccinationsAdditionalDoseRatio?: Vaccinationsadditionaldoseratio;
-  vaccinationsFall2022BivalentBoosterRatio?: Vaccinationsfall2022Bivalentboosterratio;
 }
 /**
  * Details about how the test positivity ratio was calculated.
@@ -635,15 +618,13 @@ export interface CommunityLevels {
    *
    * See https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html
    * for details about how the Community Level is calculated and should be
-   * interpreted.
+   * interpretted.
    *
    * Note that we provide two versions of the Community Level. One is called
-   * canCommunityLevel which is calculated using CAN's data sources and is
-   * available for states, counties, and metros. It is updated daily though
-   * depends on hospital data which may only update weekly for counties. The
-   * other is called cdcCommunityLevel and is the raw Community Level published
-   * by the CDC. It is only available for counties and is updated on a weekly
-   * basis.
+   * canCommunityLevel which is calculated on a daily basis using CAN's data
+   * sources and is available for states, counties, and metros.  The other is
+   * called cdcCommunityLevel and is the raw Community Level published by the
+   * CDC. It is only available for counties, and updates on a weekly basis.
    *
    */
   cdcCommunityLevel: CommunityLevel;
@@ -659,15 +640,13 @@ export interface CommunityLevels {
    *
    * See https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html
    * for details about how the Community Level is calculated and should be
-   * interpreted.
+   * interpretted.
    *
    * Note that we provide two versions of the Community Level. One is called
-   * canCommunityLevel which is calculated using CAN's data sources and is
-   * available for states, counties, and metros. It is updated daily though
-   * depends on hospital data which may only update weekly for counties. The
-   * other is called cdcCommunityLevel and is the raw Community Level published
-   * by the CDC. It is only available for counties and is updated on a weekly
-   * basis.
+   * canCommunityLevel which is calculated on a daily basis using CAN's data
+   * sources and is available for states, counties, and metros.  The other is
+   * called cdcCommunityLevel and is the raw Community Level published by the
+   * CDC. It is only available for counties, and updates on a weekly basis.
    *
    */
   canCommunityLevel: CommunityLevel;
@@ -691,7 +670,6 @@ export interface Actuals {
   vaccinationsInitiated?: Vaccinationsinitiated;
   vaccinationsCompleted?: Vaccinationscompleted;
   vaccinationsAdditionalDose?: Vaccinationsadditionaldose;
-  vaccinationsFall2022BivalentBooster?: Vaccinationsfall2022Bivalentbooster;
   vaccinesAdministered?: Vaccinesadministered;
   vaccinesAdministeredDemographics?: Vaccinesadministereddemographics;
   vaccinationsInitiatedDemographics?: Vaccinationsinitiateddemographics;
@@ -747,7 +725,6 @@ export interface Annotations {
   vaccinationsInitiated?: Vaccinationsinitiated1;
   vaccinationsCompleted?: Vaccinationscompleted1;
   vaccinationsAdditionalDose?: Vaccinationsadditionaldose1;
-  vaccinationsFall2022BivalentBooster?: Vaccinationsfall2022Bivalentbooster1;
   vaccinesAdministered?: Vaccinesadministered1;
   testPositivityRatio?: Testpositivityratio1;
   caseDensity?: Casedensity1;
@@ -761,7 +738,6 @@ export interface Annotations {
   vaccinationsInitiatedRatio?: Vaccinationsinitiatedratio1;
   vaccinationsCompletedRatio?: Vaccinationscompletedratio1;
   vaccinationsAdditionalDoseRatio?: Vaccinationsadditionaldoseratio1;
-  vaccinationsFall2022BivalentBoosterRatio?: Vaccinationsfall2022Bivalentboosterratio1;
 }
 /**
  * Annotations associated with one field.

--- a/src/api/schema/RegionSummaryWithTimeseries.d.ts
+++ b/src/api/schema/RegionSummaryWithTimeseries.d.ts
@@ -21,11 +21,11 @@ export type State = string | null;
  */
 export type County = string | null;
 /**
- * 3 digit Health Service Area identification code. For CBSA, state, and country regions hsa is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md
+ * 3 digit Health Service Area identification code. For CBSA, state, and country regions hsa is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md
  */
 export type Hsa = string | null;
 /**
- * Name of Health Service Area. For CBSA, state, and country regions hsaName is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md
+ * Name of Health Service Area. For CBSA, state, and country regions hsaName is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md
  */
 export type Hsaname = string | null;
 /**
@@ -55,7 +55,7 @@ export type Long = number | null;
  */
 export type Population = number;
 /**
- * Total Population of county's corresponding Health Service Area. For CBSA, state, and country regions hsaPopulation is omitted. For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md
+ * Total Population of county's corresponding Health Service Area. For CBSA, state, and country regions hsaPopulation is omitted. For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md
  */
 export type Hsapopulation = number | null;
 /**
@@ -97,11 +97,11 @@ export type Infectionrateci90 = number | null;
  */
 export type Icucapacityratio = number | null;
 /**
- * Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas
+ * Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area.
  */
 export type Bedswithcovidpatientsratio = number | null;
 /**
- * Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas
+ * Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area.
  */
 export type Weeklycovidadmissionsper100K = number | null;
 /**
@@ -116,10 +116,6 @@ export type Vaccinationscompletedratio = number | null;
  * Ratio of population that are fully vaccinated and have received a booster (or additional) dose.
  */
 export type Vaccinationsadditionaldoseratio = number | null;
-/**
- * Ratio of population that have received a bivalent vaccine dose.
- */
-export type Vaccinationsfall2022Bivalentboosterratio = number | null;
 /**
  * Risk levels for region.
  */
@@ -196,7 +192,7 @@ export type Weeklycovidadmissions = number | null;
  *
  * Information about acute bed utilization details aggregated for the county's corresponding
  * Health Service Area (HSA). For CBSA, state, and country regions these fields are omitted.
- * For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
+ * For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
  *
  * Fields:
  *  * capacity - Current staffed acute bed capacity.
@@ -233,7 +229,7 @@ export type Currentusagecovid1 = number | null;
  *
  * Information about ICU bed utilization details aggregated for the county's corresponding
  * Health Service Area (HSA). For CBSA, state, and country regions these fields are omitted.
- * For For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
+ * For For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
  *
  * Fields:
  *  * capacity - Current staffed ICU bed capacity.
@@ -305,10 +301,6 @@ export type Vaccinationscompleted = number | null;
  * Number of individuals who are fully vaccinated and have received a booster (or additional) dose.
  */
 export type Vaccinationsadditionaldose = number | null;
-/**
- * Number of individuals who have received a bivalent vaccine dose.
- */
-export type Vaccinationsfall2022Bivalentbooster = number | null;
 /**
  * Total number of vaccine doses administered.
  */
@@ -444,10 +436,6 @@ export type Vaccinationscompleted1 = FieldAnnotations;
  */
 export type Vaccinationsadditionaldose1 = FieldAnnotations;
 /**
- * Annotations for vaccinationsFall2022BivalentBooster
- */
-export type Vaccinationsfall2022Bivalentbooster1 = FieldAnnotations;
-/**
  * Annotations for vaccinesAdministered
  */
 export type Vaccinesadministered1 = FieldAnnotations;
@@ -496,13 +484,9 @@ export type Vaccinationsinitiatedratio1 = FieldAnnotations;
  */
 export type Vaccinationscompletedratio1 = FieldAnnotations;
 /**
- * Annotations for vaccinationsAdditionalDoseRatio
+ * Ratio of population that are fully vaccinated and have received a booster (or additional) dose.
  */
 export type Vaccinationsadditionaldoseratio1 = FieldAnnotations;
-/**
- * Annotations for vaccinationsFall2022BivalentBoosterRatio.
- */
-export type Vaccinationsfall2022Bivalentboosterratio1 = FieldAnnotations;
 /**
  * Date of latest data
  */
@@ -540,11 +524,11 @@ export type Infectionrateci902 = number | null;
  */
 export type Icucapacityratio2 = number | null;
 /**
- * Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas
+ * Ratio of staffed hospital beds that are currently in use by COVID patients. For counties, this is calculated using HSA-level data for the corresponding area.
  */
 export type Bedswithcovidpatientsratio2 = number | null;
 /**
- * Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area. For more on HSAs, see https://apidocs.covidactnow.org/data-definitions/#health-service-areas
+ * Number of COVID patients per 100k population admitted in the past week. For counties, this is calculated using HSA-level data for the corresponding area.
  */
 export type Weeklycovidadmissionsper100K2 = number | null;
 /**
@@ -559,10 +543,6 @@ export type Vaccinationscompletedratio2 = number | null;
  * Ratio of population that are fully vaccinated and have received a booster (or additional) dose.
  */
 export type Vaccinationsadditionaldoseratio2 = number | null;
-/**
- * Ratio of population that have received a bivalent vaccine dose.
- */
-export type Vaccinationsfall2022Bivalentboosterratio2 = number | null;
 /**
  * Date of timeseries data point
  */
@@ -604,7 +584,7 @@ export type Hospitalbeds2 = HospitalResourceUtilizationWithAdmissions;
  *
  * Information about acute bed utilization details aggregated for the county's corresponding
  * Health Service Area (HSA). For CBSA, state, and country regions these fields are omitted.
- * For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
+ * For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
  *
  * Fields:
  *  * capacity - Current staffed acute bed capacity.
@@ -629,7 +609,7 @@ export type Icubeds2 = HospitalResourceUtilization;
  *
  * Information about ICU bed utilization details aggregated for the county's corresponding
  * Health Service Area (HSA). For CBSA, state, and country regions these fields are omitted.
- * For For more on HSAs see: https://github.com/act-now-coalition/covid-data-model/blob/main/data/misc/README.md"
+ * For For more on HSAs see: https://github.com/covid-projections/covid-data-model/blob/main/data/misc/README.md"
  *
  * Fields:
  *  * capacity - Current staffed ICU bed capacity.
@@ -701,10 +681,6 @@ export type Vaccinationscompleted2 = number | null;
  * Number of individuals who are fully vaccinated and have received a booster (or additional) dose.
  */
 export type Vaccinationsadditionaldose2 = number | null;
-/**
- * Number of individuals who have received a bivalent vaccine dose.
- */
-export type Vaccinationsfall2022Bivalentbooster2 = number | null;
 /**
  * Total number of vaccine doses administered.
  */
@@ -811,7 +787,6 @@ export interface Metrics {
   vaccinationsInitiatedRatio?: Vaccinationsinitiatedratio;
   vaccinationsCompletedRatio?: Vaccinationscompletedratio;
   vaccinationsAdditionalDoseRatio?: Vaccinationsadditionaldoseratio;
-  vaccinationsFall2022BivalentBoosterRatio?: Vaccinationsfall2022Bivalentboosterratio;
 }
 /**
  * Details about how the test positivity ratio was calculated.
@@ -866,15 +841,13 @@ export interface CommunityLevels {
    *
    * See https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html
    * for details about how the Community Level is calculated and should be
-   * interpreted.
+   * interpretted.
    *
    * Note that we provide two versions of the Community Level. One is called
-   * canCommunityLevel which is calculated using CAN's data sources and is
-   * available for states, counties, and metros. It is updated daily though
-   * depends on hospital data which may only update weekly for counties. The
-   * other is called cdcCommunityLevel and is the raw Community Level published
-   * by the CDC. It is only available for counties and is updated on a weekly
-   * basis.
+   * canCommunityLevel which is calculated on a daily basis using CAN's data
+   * sources and is available for states, counties, and metros.  The other is
+   * called cdcCommunityLevel and is the raw Community Level published by the
+   * CDC. It is only available for counties, and updates on a weekly basis.
    *
    */
   cdcCommunityLevel: CommunityLevel;
@@ -890,15 +863,13 @@ export interface CommunityLevels {
    *
    * See https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html
    * for details about how the Community Level is calculated and should be
-   * interpreted.
+   * interpretted.
    *
    * Note that we provide two versions of the Community Level. One is called
-   * canCommunityLevel which is calculated using CAN's data sources and is
-   * available for states, counties, and metros. It is updated daily though
-   * depends on hospital data which may only update weekly for counties. The
-   * other is called cdcCommunityLevel and is the raw Community Level published
-   * by the CDC. It is only available for counties and is updated on a weekly
-   * basis.
+   * canCommunityLevel which is calculated on a daily basis using CAN's data
+   * sources and is available for states, counties, and metros.  The other is
+   * called cdcCommunityLevel and is the raw Community Level published by the
+   * CDC. It is only available for counties, and updates on a weekly basis.
    *
    */
   canCommunityLevel: CommunityLevel;
@@ -922,7 +893,6 @@ export interface Actuals {
   vaccinationsInitiated?: Vaccinationsinitiated;
   vaccinationsCompleted?: Vaccinationscompleted;
   vaccinationsAdditionalDose?: Vaccinationsadditionaldose;
-  vaccinationsFall2022BivalentBooster?: Vaccinationsfall2022Bivalentbooster;
   vaccinesAdministered?: Vaccinesadministered;
   vaccinesAdministeredDemographics?: Vaccinesadministereddemographics;
   vaccinationsInitiatedDemographics?: Vaccinationsinitiateddemographics;
@@ -978,7 +948,6 @@ export interface Annotations {
   vaccinationsInitiated?: Vaccinationsinitiated1;
   vaccinationsCompleted?: Vaccinationscompleted1;
   vaccinationsAdditionalDose?: Vaccinationsadditionaldose1;
-  vaccinationsFall2022BivalentBooster?: Vaccinationsfall2022Bivalentbooster1;
   vaccinesAdministered?: Vaccinesadministered1;
   testPositivityRatio?: Testpositivityratio1;
   caseDensity?: Casedensity1;
@@ -992,7 +961,6 @@ export interface Annotations {
   vaccinationsInitiatedRatio?: Vaccinationsinitiatedratio1;
   vaccinationsCompletedRatio?: Vaccinationscompletedratio1;
   vaccinationsAdditionalDoseRatio?: Vaccinationsadditionaldoseratio1;
-  vaccinationsFall2022BivalentBoosterRatio?: Vaccinationsfall2022Bivalentboosterratio1;
 }
 /**
  * Annotations associated with one field.
@@ -1040,7 +1008,6 @@ export interface MetricsTimeseriesRow {
   vaccinationsInitiatedRatio?: Vaccinationsinitiatedratio2;
   vaccinationsCompletedRatio?: Vaccinationscompletedratio2;
   vaccinationsAdditionalDoseRatio?: Vaccinationsadditionaldoseratio2;
-  vaccinationsFall2022BivalentBoosterRatio?: Vaccinationsfall2022Bivalentboosterratio2;
   date: Date1;
 }
 /**
@@ -1062,7 +1029,6 @@ export interface ActualsTimeseriesRow {
   vaccinationsInitiated?: Vaccinationsinitiated2;
   vaccinationsCompleted?: Vaccinationscompleted2;
   vaccinationsAdditionalDose?: Vaccinationsadditionaldose2;
-  vaccinationsFall2022BivalentBooster?: Vaccinationsfall2022Bivalentbooster2;
   vaccinesAdministered?: Vaccinesadministered2;
   vaccinesAdministeredDemographics?: Vaccinesadministereddemographics1;
   vaccinationsInitiatedDemographics?: Vaccinationsinitiateddemographics1;
@@ -1073,7 +1039,7 @@ export interface ActualsTimeseriesRow {
  */
 export interface RiskLevelTimeseriesRow {
   /**
-   * Overall risk level for region.
+   * Overall risk level for region .
    */
   overall: RiskLevel;
   /**
@@ -1127,15 +1093,13 @@ export interface CommunityLevelsTimeseriesRow {
    *
    * See https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html
    * for details about how the Community Level is calculated and should be
-   * interpreted.
+   * interpretted.
    *
    * Note that we provide two versions of the Community Level. One is called
-   * canCommunityLevel which is calculated using CAN's data sources and is
-   * available for states, counties, and metros. It is updated daily though
-   * depends on hospital data which may only update weekly for counties. The
-   * other is called cdcCommunityLevel and is the raw Community Level published
-   * by the CDC. It is only available for counties and is updated on a weekly
-   * basis.
+   * canCommunityLevel which is calculated on a daily basis using CAN's data
+   * sources and is available for states, counties, and metros.  The other is
+   * called cdcCommunityLevel and is the raw Community Level published by the
+   * CDC. It is only available for counties, and updates on a weekly basis.
    *
    */
   cdcCommunityLevel: CommunityLevel;
@@ -1151,15 +1115,13 @@ export interface CommunityLevelsTimeseriesRow {
    *
    * See https://www.cdc.gov/coronavirus/2019-ncov/science/community-levels.html
    * for details about how the Community Level is calculated and should be
-   * interpreted.
+   * interpretted.
    *
    * Note that we provide two versions of the Community Level. One is called
-   * canCommunityLevel which is calculated using CAN's data sources and is
-   * available for states, counties, and metros. It is updated daily though
-   * depends on hospital data which may only update weekly for counties. The
-   * other is called cdcCommunityLevel and is the raw Community Level published
-   * by the CDC. It is only available for counties and is updated on a weekly
-   * basis.
+   * canCommunityLevel which is calculated on a daily basis using CAN's data
+   * sources and is available for states, counties, and metros.  The other is
+   * called cdcCommunityLevel and is the raw Community Level published by the
+   * CDC. It is only available for counties, and updates on a weekly basis.
    *
    */
   canCommunityLevel: CommunityLevel;

--- a/src/screens/HomePage/HomePage.tsx
+++ b/src/screens/HomePage/HomePage.tsx
@@ -2,6 +2,7 @@ import React, { useRef, useEffect, useState, useMemo } from 'react';
 import Fade from '@material-ui/core/Fade';
 import { useLocation } from 'react-router-dom';
 import USRiskMap from 'components/USMap/USRiskMap';
+import USVaccineMap from 'components/USMap/USVaccineMap';
 import { NavBarSearch } from 'components/NavBar';
 import { NavAllOtherPages } from 'components/NavBar';
 import AppMetaTags from 'components/AppMetaTags/AppMetaTags';
@@ -9,7 +10,7 @@ import EnsureSharingIdInUrl from 'components/EnsureSharingIdInUrl';
 import PartnersSection from 'components/PartnersSection/PartnersSection';
 import CompareMain from 'components/Compare/CompareMain';
 import Explore, { ExploreMetric } from 'components/Explore';
-import { formatMetatagDate } from 'common/utils';
+import { formatMetatagDate, formatPercent } from 'common/utils';
 import { getFilterLimit } from 'components/Search';
 import HomepageStructuredData from 'screens/HomePage/HomepageStructuredData';
 import { filterGeolocatedRegions } from 'common/regions';
@@ -23,16 +24,22 @@ import {
   Content,
   HomePageBlock,
   ColumnCentered,
-  MapDescriptionText,
+  VaccinationsThermometerHeading,
   AboutLink,
+  MapDescriptionText,
 } from './HomePage.style';
 import SearchAutocomplete from 'components/Search';
-import { CommunityLevelThermometer } from 'components/HorizontalThermometer';
+import {
+  CommunityLevelThermometer,
+  VaccinationsThermometer,
+} from 'components/HorizontalThermometer';
 import HomepageItems from 'components/RegionItem/HomepageItems';
 import { useBreakpoint, useFinalAutocompleteLocations } from 'common/hooks';
 import { largestMetroFipsForExplore, MapView } from 'screens/HomePage/utils';
 import { DonateButtonHeart } from 'components/DonateButton';
+import SiteSummaryJSON from 'assets/data/site-summary.json';
 import { MapBlock } from './MapBlock';
+import { TooltipMode } from 'components/USMap/USMapTooltip';
 import NationalText from 'components/NationalText';
 import Recommendations from 'components/Recommend/Recommendations';
 import regions, { USA } from 'common/regions';
@@ -84,6 +91,7 @@ export default function HomePage() {
   const searchLocations = useFinalAutocompleteLocations();
 
   const isMobileNavBar = useBreakpoint(800);
+  const isMobile = useBreakpoint(600);
   const hasScrolled = useShowPastPosition(450);
   const showDonateButton = !isMobileNavBar || (isMobileNavBar && !hasScrolled);
   const renderNavBarSearch = () => (
@@ -152,6 +160,36 @@ export default function HomePage() {
               }
               mapDescription={getRiskMapDescription()}
             />
+
+            <MapBlock
+              title="Vaccination Progress"
+              subtitle={getVaccinationProgressSubtitle()}
+              renderMap={locationScope => (
+                <USVaccineMap
+                  showCounties={locationScope === MapView.COUNTIES}
+                  tooltipMode={
+                    // TODO(michael): There's some sort of bug / performance issue on iOS that makes
+                    // the mobile tooltip on the county view unusable.
+                    isMobile && locationScope === MapView.STATES
+                      ? TooltipMode.ACTIVATE_ON_CLICK
+                      : TooltipMode.ACTIVATE_ON_HOVER
+                  }
+                />
+              )}
+              renderThermometer={() => (
+                <>
+                  <VaccinationsThermometerHeading>
+                    Population with <b>1+ dose</b>
+                  </VaccinationsThermometerHeading>
+                  <VaccinationsThermometer />
+                </>
+              )}
+              infoLink={
+                <AboutLink to="/covid-community-level-metrics#percent-vaccinated">
+                  About this data
+                </AboutLink>
+              }
+            />
             <HomePageBlock
               ref={exploreSectionRef}
               id="explore-hospitalizations"
@@ -186,6 +224,19 @@ export default function HomePage() {
           </Content>
         </div>
       </main>
+    </>
+  );
+}
+
+function getVaccinationProgressSubtitle() {
+  const { totalVaccinationsInitiated, totalPopulation } = SiteSummaryJSON.usa;
+  const percentVaccinated = formatPercent(
+    totalVaccinationsInitiated / totalPopulation,
+  );
+  return (
+    <>
+      <b>{percentVaccinated}</b> of the entire U.S. population has received{' '}
+      <b>1+ dose</b>.
     </>
   );
 }


### PR DESCRIPTION
This reverts commit 8a0aa10adf7aa450412de2fcf50b9f8ac2df0e4d. 

We're waiting to ship all the CAN update changes at once (and send out a newsletter etc) so I shouldn't have merged this change. 

I've reopened https://github.com/act-now-coalition/covid-act-now-website/pull/7149 for when we do, eventually, want to merge this