### PR TITLE
Add disclaimer per CAN Copy Audit '23 Q1 doc.

### DIFF
--- a/src/components/LearnDisclaimer/LearnDisclaimer.stories.tsx
+++ b/src/components/LearnDisclaimer/LearnDisclaimer.stories.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import LearnDisclaimer from './LearnDisclaimer';
+
+export default {
+  title: 'Components/LearnDisclaimer',
+  component: LearnDisclaimer,
+};
+
+export const Example = (args: any) => <LearnDisclaimer />;

--- a/src/components/LearnDisclaimer/LearnDisclaimer.tsx
+++ b/src/components/LearnDisclaimer/LearnDisclaimer.tsx
@@ -1,0 +1,26 @@
+import { Box } from '@material-ui/core';
+import ExternalLink from 'components/ExternalLink';
+import React from 'react';
+
+const LearnDisclaimer: React.FC = () => {
+  return (
+    <Box
+      border={1}
+      borderRadius={3}
+      padding={1}
+      bgcolor="#FFFCD9"
+      maxWidth={600}
+      marginBottom={3}
+    >
+      This page is no longer being updated with the latest information. While we
+      continue to surface this content for archival purposes, we recommend that
+      you visit more regularly updated resources, such as from the{' '}
+      <ExternalLink href="https://www.cdc.gov/coronavirus/2019-ncov/index.html">
+        CDC
+      </ExternalLink>
+      .
+    </Box>
+  );
+};
+
+export default LearnDisclaimer;

--- a/src/screens/Learn/Alerts/Alerts.tsx
+++ b/src/screens/Learn/Alerts/Alerts.tsx
@@ -12,6 +12,7 @@ import { aboutOurAlertsContent } from 'cms-content/learn';
 import { LargeOutlinedButton } from 'components/ButtonSystem';
 import { EventCategory } from 'components/Analytics';
 import ArrowForwardIcon from '@material-ui/icons/ArrowForward';
+import LearnDisclaimer from 'components/LearnDisclaimer/LearnDisclaimer';
 
 const Alerts: React.FC = () => {
   const {
@@ -36,6 +37,7 @@ const Alerts: React.FC = () => {
           <Breadcrumbs item={{ to: '/learn', label: 'Learn' }} />
         </BreadcrumbsContainer>
         <LearnHeading1>{pageHeader}</LearnHeading1>
+        <LearnDisclaimer />
         <MarkdownContent source={bodyText} />
         <ButtonWrapper>
           <LargeOutlinedButton

--- a/src/screens/Learn/Articles/Article.tsx
+++ b/src/screens/Learn/Articles/Article.tsx
@@ -16,6 +16,7 @@ import { Article } from 'cms-content/articles/utils';
 import SmallShareButtons from 'components/SmallShareButtons';
 import Footer from 'screens/Learn/Footer/Footer';
 import { getCovidExplainedFooter } from 'screens/Learn/Explained';
+import LearnDisclaimer from 'components/LearnDisclaimer/LearnDisclaimer';
 
 const ArticlePage: React.FC<{
   article: Article;
@@ -66,6 +67,7 @@ const ArticlePage: React.FC<{
           <Breadcrumbs item={parentItem} />
         </BreadcrumbsContainer>
         <LearnHeading1>{header}</LearnHeading1>
+        <LearnDisclaimer />
         <SmallSubtext source={smallSubtextCopy} />
         <HeaderShareButtonsWrapper>
           <SmallShareButtons {...shareButtonProps} />

--- a/src/screens/Learn/Articles/ArticlesLanding.tsx
+++ b/src/screens/Learn/Articles/ArticlesLanding.tsx
@@ -12,6 +12,7 @@ import {
 import { CardsContainer } from '../Learn.style';
 import LandingPageCard from '../SharedComponents/LandingPageCard';
 import { Article } from 'cms-content/articles';
+import LearnDisclaimer from 'components/LearnDisclaimer/LearnDisclaimer';
 
 const ArticlesLanding: React.FC<{
   title: string;
@@ -42,6 +43,7 @@ const ArticlesLanding: React.FC<{
           <Breadcrumbs item={{ to: '/learn', label: 'Learn' }} />
         </BreadcrumbsContainer>
         <LearnHeading1>{title}</LearnHeading1>
+        <LearnDisclaimer />
         {sectionIntro && (
           <ArticlesLandingIntro>{sectionIntro}</ArticlesLandingIntro>
         )}

--- a/src/screens/Learn/Faq/Faq.tsx
+++ b/src/screens/Learn/Faq/Faq.tsx
@@ -22,6 +22,7 @@ import {
   parseDateString,
   formatDateTime,
 } from '@actnowcoalition/time-utils';
+import LearnDisclaimer from 'components/LearnDisclaimer/LearnDisclaimer';
 
 const Faq: React.FC = () => {
   const {
@@ -60,6 +61,7 @@ const Faq: React.FC = () => {
           <Breadcrumbs item={{ to: '/learn', label: 'Learn' }} />
         </BreadcrumbsContainer>
         <LearnHeading1>{header}</LearnHeading1>
+        <LearnDisclaimer />
         {intro && <MarkdownContent source={intro} />}
         <LastUpdatedDate>
           Last updated{' '}

--- a/src/screens/Learn/Glossary/Glossary.tsx
+++ b/src/screens/Learn/Glossary/Glossary.tsx
@@ -21,6 +21,7 @@ import {
   parseDateString,
   formatDateTime,
 } from '@actnowcoalition/time-utils';
+import LearnDisclaimer from 'components/LearnDisclaimer/LearnDisclaimer';
 
 const GlossaryTerm: React.FC<{ term: Term }> = ({ term }) => {
   return (
@@ -61,6 +62,7 @@ const Glossary: React.FC = () => {
           <Breadcrumbs item={{ to: '/learn', label: 'Learn' }} />
         </BreadcrumbsContainer>
         <LearnHeading1>{header}</LearnHeading1>
+        <LearnDisclaimer />
         {intro && <MarkdownContent source={intro} />}
         <LastUpdatedDate>
           Last updated{' '}


### PR DESCRIPTION
Added to: FAQ, Glossary, Research Rundown, COVID Explained Homepage, COVID Explained articles.

Example:
![image](https://user-images.githubusercontent.com/206364/211933904-8e58f79f-f598-46cf-a9f9-6873bc521660.png)
