### PR TITLE
Fix override CMS github URL.

### DIFF
--- a/public/admin-overrides/config.yml
+++ b/public/admin-overrides/config.yml
@@ -6,7 +6,7 @@
 
 backend:
   name: github
-  repo: act-now-coalition/covid-act-now-website
+  repo: act-now-coalition/covid-data-model
   branch: main
   base_url: https://api.netlify.com
 


### PR DESCRIPTION
Looks like this got modified incorrectly when updating repo paths yesterday and I missed it in the review.

https://github.com/act-now-coalition/covid-act-now-website/pull/7146/files#diff-04f8ec328361d433b1387fda9541b137c12d2d577163b9f8e76c702face9eb29L9
![image](https://user-images.githubusercontent.com/206364/212129791-16e4d0ae-d1a9-4982-b308-0edad3e066db.png)
