### PR TITLE
BUG: Fix map type info local storage error

### DIFF
--- a/src/components/NewLocationPage/CountyMap/CountyMap.tsx
+++ b/src/components/NewLocationPage/CountyMap/CountyMap.tsx
@@ -27,7 +27,7 @@ import { StorageKeys, useLocalStorage } from 'common/utils/storage';
 // we need to keep "Risk levels" for COMMUNITY_LEVEL to prevent breaking the
 // state for users that had selected "Risk levels" in the past.
 enum MapType {
-  VACCINATIONS = '% Boosted',
+  VACCINATIONS = '% Vaccinated',
   COMMUNITY_LEVEL = 'Risk levels',
 }
 
@@ -36,6 +36,13 @@ interface MapTypeInfo {
   colorMap: (locationSummary: LocationSummary) => string;
   mapButtonLabel: string;
 }
+
+const communityLevelMapInfo = {
+  thermometer: <CommunityLevelThermometer />,
+  colorMap: (locationSummary: LocationSummary) =>
+    getAlertColor(locationSummary),
+  mapButtonLabel: 'Community risk level',
+};
 
 const MAP_TYPE_INFO: { [key in MapType]: MapTypeInfo } = {
   [MapType.VACCINATIONS]: {
@@ -53,12 +60,7 @@ const MAP_TYPE_INFO: { [key in MapType]: MapTypeInfo } = {
       vaccineColorFromLocationSummary(locationSummary),
     mapButtonLabel: '% Boosted',
   },
-  [MapType.COMMUNITY_LEVEL]: {
-    thermometer: <CommunityLevelThermometer />,
-    colorMap: (locationSummary: LocationSummary) =>
-      getAlertColor(locationSummary),
-    mapButtonLabel: 'Community risk level',
-  },
+  [MapType.COMMUNITY_LEVEL]: communityLevelMapInfo,
 };
 
 /**
@@ -108,7 +110,8 @@ const CountyMap: React.FC<{ region: Region }> = React.memo(({ region }) => {
     }
   };
 
-  const mapTypeInfo = MAP_TYPE_INFO[mapType];
+  // If local storage is empty or not a valid map type, default to community level
+  const mapTypeInfo = MAP_TYPE_INFO[mapType] ?? communityLevelMapInfo;
 
   const bottomPosition = useMapContainerOffset();
 


### PR DESCRIPTION
Addresses page load/map selection bug due to local storage variable change: https://sentry.io/organizations/covidactnow/issues/3874968796/?project=5444052&referrer=issue-stream

Reverts the `COUNTY_MAP_TYPE` local storage variable value change, and safeguards the map selection such that, if an invalid value is found in the browser's local storage the map will default to the community risk level map. 

Once the user toggles the map/makes a selection, the variable will be updated to the expected value. 

**To Test:**
1. Visit the [preview link](https://covid-projections-git-smcclure17-map-hotfix-covidactnow.vercel.app/?s=44833229),
2. View the browser's local storage in dev-tools (on chrome: hit `f12` > go to `Application` tab > storage > local storage). 
3. Navigate to any location page and toggle the map type from risk levels to vaccinations. Note that a storage variable `COUNTY_MAP_TYPE` should now be saved. 
4. Navigate back home and edit the `COUNTY_MAP_TYPE` variable to be anything (e.g. "% Boosted")
5. Navigate back to any location page, and the page should load successfully.

**Additional Context:**
<img width="1309" alt="image" src="https://user-images.githubusercontent.com/55333380/212493627-7d2577c6-110a-4d93-8a93-a303eff0314f.png">


**Note:**
In the case that the local storage variable contains an invalid value, this fix leaves the map buttons un-highlighted. I'm looking into how to fix this, but I think it's high priority we fix the page load issues, first. 
<img width="329" alt="image" src="https://user-images.githubusercontent.com/55333380/212493484-fa60fc9b-27fd-473e-8afd-c9ecf45ce527.png">

