### PR TITLE
Update preview and compare link urls

### DIFF
--- a/.github/workflows/update-snapshot.yml
+++ b/.github/workflows/update-snapshot.yml
@@ -72,7 +72,7 @@ jobs:
             * Point at new share images URL.
 
       - name: Wait for Preview URL to be live
-        run: npx wait-on -t 120000 https://covid-projections-git-bump-snapshot-${{env.RUN_ID}}-covidactnow.now.sh/compare/ || echo 'Preview URL failed to load.'
+        run: npx wait-on -t 120000 https://covid-act-now-website-git-bump-snapshot-${{env.RUN_ID}}-covidactnow.now.sh/compare/ || echo 'Preview URL failed to load.'
 
       - name: Read slack-summary.txt
         id: slack_summary
@@ -95,6 +95,6 @@ jobs:
           args: |
             PR to update the website to snapshot ${{env.SNAPSHOT_ID}} (with updated map colors and share images) is available.
             PR: https://github.com/act-now-coalition/covid-act-now-website/pull/${{env.PULL_REQUEST_NUMBER}}
-            Preview: https://covid-projections-git-bump-snapshot-${{env.RUN_ID}}-covidactnow.now.sh/
-            Compare: https://covid-projections-git-bump-snapshot-${{env.RUN_ID}}-covidactnow.now.sh/internal/compare/
+            Preview: https://covid-act-now-website-git-bump-snapshot-${{env.RUN_ID}}-covidactnow.now.sh/
+            Compare: https://covid-act-now-website-git-bump-snapshot-${{env.RUN_ID}}-covidactnow.now.sh/internal/compare/
             ${{steps.slack_summary.outputs.text}}


### PR DESCRIPTION
Update preview and compare link URLs.

This is a follow-up to
- Updating Vercel project name from `covid-projections` to `covid-act-now-website`.
- [This comment](https://github.com/act-now-coalition/covid-act-now-website/pull/7146#discussion_r1066253405).