### PR TITLE
Add new CDC source for cases data

### DIFF
--- a/src/common/utils/provenance.tsx
+++ b/src/common/utils/provenance.tsx
@@ -144,17 +144,29 @@ const metricToSourceMap: RegionSourceMap = {
         sourceName: 'The New York Times',
         url: 'https://github.com/nytimes/covid-19-data',
       },
+      {
+        sourceName: 'CDC COVID Data Tracker',
+        url: 'https://covid.cdc.gov/covid-data-tracker/#county-view',
+      },
     ],
     metro: [
       {
         sourceName: 'The New York Times',
         url: 'https://github.com/nytimes/covid-19-data',
       },
+      {
+        sourceName: 'CDC COVID Data Tracker',
+        url: 'https://covid.cdc.gov/covid-data-tracker/#county-view',
+      },
     ],
     county: [
       {
         sourceName: 'The New York Times',
         url: 'https://github.com/nytimes/covid-19-data',
+      },
+      {
+        sourceName: 'CDC COVID Data Tracker',
+        url: 'https://covid.cdc.gov/covid-data-tracker/#county-view',
       },
     ],
   },

--- a/src/common/utils/provenance.tsx
+++ b/src/common/utils/provenance.tsx
@@ -71,17 +71,29 @@ const metricToSourceMap: RegionSourceMap = {
         sourceName: 'The New York Times',
         url: 'https://github.com/nytimes/covid-19-data',
       },
+      {
+        sourceName: 'CDC COVID Data Tracker',
+        url: 'https://covid.cdc.gov/covid-data-tracker/#county-view',
+      },
     ],
     metro: [
       {
         sourceName: 'The New York Times',
         url: 'https://github.com/nytimes/covid-19-data',
       },
+      {
+        sourceName: 'CDC COVID Data Tracker',
+        url: 'https://covid.cdc.gov/covid-data-tracker/#county-view',
+      },
     ],
     county: [
       {
         sourceName: 'The New York Times',
         url: 'https://github.com/nytimes/covid-19-data',
+      },
+      {
+        sourceName: 'CDC COVID Data Tracker',
+        url: 'https://covid.cdc.gov/covid-data-tracker/#county-view',
       },
     ],
   },

--- a/src/common/utils/provenance.tsx
+++ b/src/common/utils/provenance.tsx
@@ -39,17 +39,29 @@ const metricToSourceMap: RegionSourceMap = {
         sourceName: 'The New York Times',
         url: 'https://github.com/nytimes/covid-19-data',
       },
+      {
+        sourceName: 'CDC COVID Data Tracker',
+        url: 'https://covid.cdc.gov/covid-data-tracker/#county-view',
+      },
     ],
     metro: [
       {
         sourceName: 'The New York Times',
         url: 'https://github.com/nytimes/covid-19-data',
       },
+      {
+        sourceName: 'CDC COVID Data Tracker',
+        url: 'https://covid.cdc.gov/covid-data-tracker/#county-view',
+      },
     ],
     county: [
       {
         sourceName: 'The New York Times',
         url: 'https://github.com/nytimes/covid-19-data',
+      },
+      {
+        sourceName: 'CDC COVID Data Tracker',
+        url: 'https://covid.cdc.gov/covid-data-tracker/#county-view',
       },
     ],
   },


### PR DESCRIPTION
These sources aren't automatically compiled from the API data, so we must update them manually. 

This modifies the text in the "About this data" modal:
<img width="638" alt="image" src="https://user-images.githubusercontent.com/55333380/229011941-ed3a4f75-417e-4162-a541-86812df02b7b.png">
