### PR TITLE
Display below-the-fold charts even if data is stale

### DIFF
--- a/src/common/metrics/admissions_per_100k.tsx
+++ b/src/common/metrics/admissions_per_100k.tsx
@@ -99,7 +99,7 @@ function renderStatus(projections: Projections): React.ReactElement {
   ) {
     return (
       <Fragment>
-        Unable to generate{' '}
+        Unable to generate up-to-date{' '}
         {AdmissionsPer100kMetric.extendedMetricName.toLowerCase()}. This could
         be due to insufficient data.
       </Fragment>

--- a/src/common/metrics/case_density.tsx
+++ b/src/common/metrics/case_density.tsx
@@ -71,7 +71,7 @@ function renderStatus(projections: Projections): React.ReactElement {
   ) {
     return (
       <Fragment>
-        Unable to generate{' '}
+        Unable to generate up-to-date{' '}
         {CaseIncidenceMetric.extendedMetricName.toLowerCase()}. This could be
         due to insufficient data.
       </Fragment>

--- a/src/common/metrics/case_growth.tsx
+++ b/src/common/metrics/case_growth.tsx
@@ -80,8 +80,9 @@ function renderStatus(projections: Projections): React.ReactElement {
   if (rt === null) {
     return (
       <Fragment>
-        Unable to generate {CaseGrowthMetric.extendedMetricName.toLowerCase()}.
-        This could be due to insufficient data.
+        Unable to generate up-to-date{' '}
+        {CaseGrowthMetric.extendedMetricName.toLowerCase()}. This could be due
+        to insufficient data.
       </Fragment>
     );
   }

--- a/src/common/metrics/positive_rate.tsx
+++ b/src/common/metrics/positive_rate.tsx
@@ -82,7 +82,7 @@ function renderStatus(projections: Projections) {
   if (currentTestPositiveRate === null) {
     return (
       <Fragment>
-        Unable to generate{' '}
+        Unable to generate up-to-date{' '}
         {PositiveTestRateMetric.extendedMetricName.toLowerCase()}. This could be
         due to insufficient data.
       </Fragment>

--- a/src/common/metrics/ratio_beds_with_covid_patients.tsx
+++ b/src/common/metrics/ratio_beds_with_covid_patients.tsx
@@ -74,7 +74,7 @@ function renderStatus(projections: Projections): React.ReactElement {
   if (currentRatioBedsWithCovid === null) {
     return (
       <Fragment>
-        Unable to generate{' '}
+        Unable to generate up-to-date{' '}
         {RatioBedsWithCovidPatientsMetric.extendedMetricName.toLowerCase()}.
         This could be due to insufficient data.
       </Fragment>

--- a/src/common/metrics/weekly_new_cases_per_100k.tsx
+++ b/src/common/metrics/weekly_new_cases_per_100k.tsx
@@ -82,7 +82,7 @@ function renderStatus(projections: Projections): React.ReactElement {
   ) {
     return (
       <Fragment>
-        Unable to generate{' '}
+        Unable to generate up-to-date{' '}
         {WeeklyNewCasesPer100kMetric.extendedMetricName.toLowerCase()}. This
         could be due to insufficient data.
       </Fragment>

--- a/src/components/Charts/ChartBlock.tsx
+++ b/src/components/Charts/ChartBlock.tsx
@@ -12,12 +12,14 @@ import {
 import {
   ChartGroup,
   MetricChartInfo,
+  MetricType,
   getValueInfo,
   trackTabClick,
 } from 'components/Charts/Groupings';
 import { MetricValues } from 'common/models/Projections';
 import ChartFooter from 'components/NewLocationPage/ChartFooter/ChartFooter';
 import { Metric } from 'common/metricEnum';
+import { getRegionMetricOverride } from 'cms-content/region-overrides';
 
 const ChartBlock: React.FC<{
   isMobile: boolean;
@@ -52,7 +54,7 @@ const ChartBlock: React.FC<{
 
   const TabsWrapper = metricList.length === 1 ? InactiveTabWrapper : ChartTabs;
 
-  const { unformattedValue, formattedValue } = getValueInfo(
+  const { formattedValue } = getValueInfo(
     stats,
     metricList[activeTabIndex],
     projections,
@@ -61,12 +63,13 @@ const ChartBlock: React.FC<{
   // HACK: Vaccination metric returns bivalent booster data, but we only
   // want to not show the footer if there is no 1+ dose data
   const metric = metricList[activeTabIndex].metric;
-  const vaccinationsInitiated =
-    projections.primary.vaccinationsInfo?.peopleInitiated;
-  const hasValue =
-    metric === Metric.VACCINATIONS
-      ? Number.isFinite(vaccinationsInitiated)
-      : Number.isFinite(unformattedValue);
+  const isKeyMetric =
+    metricList[activeTabIndex].metricType === MetricType.KEY_METRIC;
+
+  // HACK: We don't have a blocking mechanism for the ExploreMetrics, so always assume they are not blocked.
+  const isBlocked = isKeyMetric
+    ? getRegionMetricOverride(region, metric as Metric)?.blocked
+    : false;
 
   // Used to make sure user can change tabs after landing on a page via a share link (and having a tab auto-selected)
   const [hasSelectedSharedTab, setHasSelectedSharedTab] = useState<boolean>(
@@ -117,7 +120,7 @@ const ChartBlock: React.FC<{
         })}
       </TabsWrapper>
       {metricList[activeTabIndex].renderChart(projections)}
-      {hasValue && (
+      {!isBlocked && (
         <ChartFooter
           metric={metricList[activeTabIndex].metric}
           projections={projections}

--- a/src/components/Charts/MetricChart.tsx
+++ b/src/components/Charts/MetricChart.tsx
@@ -19,7 +19,10 @@ import { getMetricStatusText } from 'common/metric';
 import { ScreenshotReady } from 'components/Screenshot';
 import { MarkdownContent } from 'components/Markdown';
 import { useChartHeightForBreakpoint } from 'common/hooks';
-import { getRegionMetricDisclaimer } from 'cms-content/region-overrides';
+import {
+  getRegionMetricDisclaimer,
+  getRegionMetricOverride,
+} from 'cms-content/region-overrides';
 
 // TODO(michael): Rename to `Chart` once we get rid of existing (highcharts) Chart component.
 // TODO(michael): Update ChartsHolder to use this component instead of the individual chart components.
@@ -35,8 +38,10 @@ const MetricChart = React.memo(
     height?: number;
   }) => {
     const chartHeight = height ? height : useChartHeightForBreakpoint();
-    if (!projections.hasMetric(metric)) {
-      // See if the data has been blocked and there is a disclaimer.
+    const isBlocked = getRegionMetricOverride(projections.region, metric)
+      ?.blocked;
+    if (isBlocked) {
+      // See if the blocked data has a disclaimer.
       const blockedDisclaimer = getRegionMetricDisclaimer(
         projections.region,
         metric,


### PR DESCRIPTION
Per https://docs.google.com/document/d/1GrBTA-r35uhnIbpbIOJi5LH8PWba7gfK2WNQVeqap0Y/edit

Display Metric charts even if the data is older than the (current) 14 day cutoff threshold. Charts are still blocked/removed if the metric has been blocked via an override. 