### PR TITLE
Prioritize hospital metrics above and below the fold, and in compare

### DIFF
--- a/src/components/Charts/Groupings.tsx
+++ b/src/components/Charts/Groupings.tsx
@@ -56,23 +56,6 @@ export const CHART_GROUPS: ChartGroup[] = [
     groupHeader: GroupHeader.COMMUNITY_LEVEL,
     metricList: [
       {
-        metric: Metric.WEEKLY_CASES_PER_100K,
-        metricType: MetricType.KEY_METRIC,
-        renderTabLabel: (metricValue, projections) => (
-          <ChartTab
-            metricName={getMetricName(Metric.WEEKLY_CASES_PER_100K)}
-            subLabel={metricSubLabelText[Metric.WEEKLY_CASES_PER_100K]}
-            metricValueInfo={metricValue}
-          />
-        ),
-        renderChart: projections => (
-          <MetricChart
-            metric={Metric.WEEKLY_CASES_PER_100K}
-            projections={projections}
-          />
-        ),
-      },
-      {
         metric: Metric.ADMISSIONS_PER_100K,
         metricType: MetricType.KEY_METRIC,
         renderTabLabel: (metricValue, projections) => (
@@ -102,6 +85,23 @@ export const CHART_GROUPS: ChartGroup[] = [
         renderChart: projections => (
           <MetricChart
             metric={Metric.RATIO_BEDS_WITH_COVID}
+            projections={projections}
+          />
+        ),
+      },
+      {
+        metric: Metric.WEEKLY_CASES_PER_100K,
+        metricType: MetricType.KEY_METRIC,
+        renderTabLabel: (metricValue, projections) => (
+          <ChartTab
+            metricName={getMetricName(Metric.WEEKLY_CASES_PER_100K)}
+            subLabel={metricSubLabelText[Metric.WEEKLY_CASES_PER_100K]}
+            metricValueInfo={metricValue}
+          />
+        ),
+        renderChart: projections => (
+          <MetricChart
+            metric={Metric.WEEKLY_CASES_PER_100K}
             projections={projections}
           />
         ),

--- a/src/components/Compare/columns.tsx
+++ b/src/components/Compare/columns.tsx
@@ -135,9 +135,9 @@ const vaccinationsColumn = new VaccinationsColumn();
 
 /** Ordered array of columns. */
 export const orderedColumns = [
-  weeklyCasesPer100kColumn,
   admissionsPer100kColumn,
   ratioBedsWithCovidColumn,
+  weeklyCasesPer100kColumn,
   infectionRateColumn,
   vaccinationsColumn,
 ];

--- a/src/components/NewLocationPage/LocationOverview/LocationOverview.tsx
+++ b/src/components/NewLocationPage/LocationOverview/LocationOverview.tsx
@@ -63,15 +63,6 @@ const LocationOverview: React.FC<{
           />
         </GridItemMetricVax>
         <GridItemMetric1
-          onClick={() => onClickMetric(Metric.WEEKLY_CASES_PER_100K)}
-        >
-          <SummaryStat
-            metric={Metric.WEEKLY_CASES_PER_100K}
-            value={stats[Metric.WEEKLY_CASES_PER_100K]}
-            projection={projections?.primary}
-          />
-        </GridItemMetric1>
-        <GridItemMetric2
           onClick={() => onClickMetric(Metric.ADMISSIONS_PER_100K)}
         >
           <SummaryStat
@@ -79,13 +70,22 @@ const LocationOverview: React.FC<{
             value={stats[Metric.ADMISSIONS_PER_100K]}
             projection={projections?.primary}
           />
-        </GridItemMetric2>
-        <GridItemMetric3
+        </GridItemMetric1>
+        <GridItemMetric2
           onClick={() => onClickMetric(Metric.RATIO_BEDS_WITH_COVID)}
         >
           <SummaryStat
             metric={Metric.RATIO_BEDS_WITH_COVID}
             value={stats[Metric.RATIO_BEDS_WITH_COVID]}
+            projection={projections?.primary}
+          />
+        </GridItemMetric2>
+        <GridItemMetric3
+          onClick={() => onClickMetric(Metric.WEEKLY_CASES_PER_100K)}
+        >
+          <SummaryStat
+            metric={Metric.WEEKLY_CASES_PER_100K}
+            value={stats[Metric.WEEKLY_CASES_PER_100K]}
             projection={projections?.primary}
           />
         </GridItemMetric3>


### PR DESCRIPTION
Reorder the community level metrics so cases are shown last

Before:
![image](https://github.com/act-now-coalition/covid-act-now-website/assets/55333380/5a5b9814-0c02-46ad-9889-49cf09806c5d)

After:
<img width="948" alt="image" src="https://github.com/act-now-coalition/covid-act-now-website/assets/55333380/29a0d5e9-f3ea-44a6-ab5c-b940c626b5b4">
