### PR TITLE
Show vaccination charts below the fold even if data is stale

### DIFF
--- a/src/common/metrics/vaccinations.tsx
+++ b/src/common/metrics/vaccinations.tsx
@@ -55,8 +55,24 @@ export const VACCINATIONS_LEVEL_INFO_MAP: LevelInfoMap = {
 
 function renderStatus(projections: Projections): React.ReactElement {
   const info = projections.primary.vaccinationsInfo;
-  if (!info) {
-    return <Fragment>No vaccination data is available.</Fragment>;
+
+  // HACK (sean): Just assume if either of the initiated/fully-vaccinated ratios are
+  // missing that the data is out of date/we have no data. AFAICT there's no instance
+  // where booster data exists but not initiated/fully-vaccinated data.
+  if (
+    info?.peopleInitiated == null ||
+    info?.ratioInitiated == null ||
+    info?.peopleVaccinated == null ||
+    info?.ratioVaccinated == null
+  ) {
+    return (
+      <Fragment>
+        Vaccination data for {projections.locationName} is out of date. We
+        display timeseries data for historical purposes, but it should not be
+        used for current guidance. Missing data may be caused by lack of
+        reporting from local sources.{' '}
+      </Fragment>
+    );
   }
   const { locationName } = projections;
 

--- a/src/common/models/ProjectionsPair.ts
+++ b/src/common/models/ProjectionsPair.ts
@@ -119,7 +119,7 @@ export function getDataset(projection: Projection, metric: Metric): Column[] {
     case Metric.HOSPITAL_USAGE:
       return projection.getDataset('icuUtilization');
     case Metric.VACCINATIONS:
-      return projection.getDataset('vaccinationsBivalentBoostedFall2022');
+      return projection.getDataset('vaccinationsCompleted');
     case Metric.WEEKLY_CASES_PER_100K:
       return projection.getDataset('weeklyNewCasesPer100k');
     case Metric.RATIO_BEDS_WITH_COVID:


### PR DESCRIPTION
Refactor `vaccinationInfo` logic to return timeseries data if the metric is out of date / gray